### PR TITLE
Fixing interactive test

### DIFF
--- a/tests/browsertests/scriptloadinteractive/index.html
+++ b/tests/browsertests/scriptloadinteractive/index.html
@@ -72,7 +72,6 @@
             } else {
                 //Probably IE.
                 node.detachEvent("onreadystatechange", onTestScriptLoad);
-                useInteractive = true;
             }
         }
     }
@@ -92,6 +91,7 @@
             node.addEventListener("load", onTestScriptLoad, false);
         } else {
             //Probably IE.
+            useInteractive = true;
             node.attachEvent("onreadystatechange", onTestScriptLoad);
         }
     


### PR DESCRIPTION
I just moved the setting of useInteractive up to where the script event is registered so it is set to true before the scripts start executing and all seems to work properly for me on my browsers. Let me know if it is still not working for you.
