### PR TITLE
maintain dependency order in build

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -7,7 +7,7 @@
 /*jslint regexp: false, plusplus: false, nomen: false */
 /*global java: false, lang: false, fileUtil: false, optimize: false,
   load: false, quit: false, print: false, logger: false, require: false,
-  pragma: false */
+  pragma: false, parse: false */
 
 "use strict";
 
@@ -30,7 +30,7 @@ var build, buildBaseConfig;
             doClosure, requireContents, pluginContents, pluginBuildFileContents,
             baseConfig, override, builtRequirePath, cmdConfig, config,
             modules, module, moduleName, builtModule, srcPath;
-    
+
         if (!args || args.length < 2) {
             print("java -jar path/to/js.jar build.js directory/containing/build.js/ build.js\n" +
                   "where build.js is the name of the build file (see example.build.js for hints on how to make a build file.");
@@ -43,11 +43,11 @@ var build, buildBaseConfig;
         if (requireBuildPath.charAt(requireBuildPath.length - 1) !== "/") {
             requireBuildPath += "/";
         }
-    
+
         ["lang", "logger", "fileUtil", "parse", "optimize", "pragma", "build"].forEach(function (path) {
             load(requireBuildPath + "jslib/" + path + ".js");
         });
-    
+
         //Next args can include a build file path as well as other build args.
         //build file path comes first. If it does not contain an = then it is
         //a build file path. Otherwise, just all build args.
@@ -57,12 +57,12 @@ var build, buildBaseConfig;
         } else {
             args.splice(0, 1);
         }
-    
+
         //Remaining args are options to the build
         cmdConfig = build.convertArrayToObject(args);
         cmdConfig.buildFile = buildFile;
         cmdConfig.requireBuildPath = requireBuildPath;
-    
+
         config = build.createConfig(cmdConfig);
         paths = config.paths;
 
@@ -73,10 +73,10 @@ var build, buildBaseConfig;
         if (!config.out && !config.cssIn) {
             //This is not just a one-off file build but a full build profile, with
             //lots of files to process.
-    
+
             //First copy all the baseUrl content
             fileUtil.copyDir((config.appDir || config.baseUrl), config.dir, /\w/, true);
-        
+
             //Adjust baseUrl if config.appDir is in play, and set up build output paths.
             buildPaths = {};
             if (config.appDir) {
@@ -143,7 +143,7 @@ var build, buildBaseConfig;
             };
             lang.mixin(baseConfig, config);
             require(baseConfig);
-    
+
             if (modules) {
                 modules.forEach(function (module) {
                     if (module.name) {
@@ -219,16 +219,16 @@ var build, buildBaseConfig;
             //Normal optimizations across modules.
 
             //JS optimizations.
-            fileNames = fileUtil.getFilteredFileList(config.dir, /\.js$/, true);    
+            fileNames = fileUtil.getFilteredFileList(config.dir, /\.js$/, true);
             for (i = 0; (fileName = fileNames[i]); i++) {
                 optimize.jsFile(fileName, fileName, config);
             }
-    
+
             //CSS optimizations
             if (config.optimizeCss && config.optimizeCss !== "none") {
                 optimize.css(config.dir, config);
             }
-    
+
             //All module layers are done, write out the build.txt file.
             fileUtil.saveUtf8File(config.dir + "build.txt", buildFileContents);
         }
@@ -242,7 +242,7 @@ var build, buildBaseConfig;
         if (buildFileContents) {
             print(buildFileContents);
         }
-        
+
     };
 
     /**
@@ -482,7 +482,7 @@ var build, buildBaseConfig;
     /**
      * Uses the module build config object to trace the dependencies for the
      * given module.
-     * 
+     *
      * @param {Object} module the module object from the build config info.
      * @param {Object} the build config object.
      *
@@ -523,43 +523,22 @@ var build, buildBaseConfig;
         layer = require._layer;
         layer.specified = require.s.contexts[require.s.ctxName].specified;
 
-        //Add any other files that did not have an explicit name on them.
-        //These are files that do not call back into require when loaded.
-        for (prop in layer.buildPathMap) {
-            if (layer.buildPathMap.hasOwnProperty(prop)) {
-                url = layer.buildPathMap[prop];
-                //Always store the url to module name mapping for use later,
-                //particularly for anonymous modules and tracking down files that
-                //did not call require.def to define a module
-                layer.buildFileToModule[url] = prop;
-
-                if (!layer.loadedFiles[url]) {
-                    //Do not add plugins to build file paths since they will
-                    //be added later, near the top of the module layer.
-                    if (prop.indexOf("require/") !== 0) {
-                        layer.buildFilePaths.push(url);
-                    }
-                    layer.loadedFiles[url] = true;
-                }
-            }
-        }
-
         //Reset config
         if (module.override) {
             require(baseConfig);
         }
-        
+
         return layer;
     };
 
     /**
      * Uses the module build config object to create an flattened version
      * of the module, with deep dependencies included.
-     * 
+     *
      * @param {Object} module the module object from the build config info.
      *
      * @param {Object} layer the layer object returned from build.traceDependencies.
-     * 
+     *
      * @param {Object} the build config object.
      *
      * @returns {Object} with two properties: "text", the text of the flattened

--- a/build/jslib/requirePatch.js
+++ b/build/jslib/requirePatch.js
@@ -9,7 +9,7 @@
 
 /*jslint nomen: false, plusplus: false, regexp: false */
 /*global load: false, require: false, logger: false, setTimeout: true,
- pragma: false, Packages: false, parse: false, java: true */
+ pragma: false, Packages: false, parse: false, java: true, define: true */
 "use strict";
 
 (function () {
@@ -26,10 +26,10 @@
         try {
             stringBuffer = new java.lang.StringBuffer();
             line = input.readLine();
-    
+
             // Byte Order Mark (BOM) - The Unicode Standard, version 3.0, page 324
             // http://www.unicode.org/faq/utf_bom.html
-            
+
             // Note that when we use utf-8, the BOM should appear as "EF BB BF", but it doesn't due to this bug in the JDK:
             // http://bugs.sun.com/bugdatabase/view_bug.do?bug_id=4508058
             if (line && line.length() && line.charAt(0) === 0xfeff) {
@@ -102,7 +102,7 @@
     //Override load so that the file paths can be collected.
     require.load = function (moduleName, contextName) {
         /*jslint evil: true */
-        var url = require.nameToUrl(moduleName, null, contextName), map,
+        var url = require.nameToUrl(moduleName, null, contextName),
             contents,
             context = require.s.contexts[contextName];
         context.loaded[moduleName] = false;
@@ -111,14 +111,15 @@
         //URLs like ones that require network access or may be too dynamic,
         //like JSONP
         if (require._isSupportedBuildUrl(url)) {
-            //Save the module name to path mapping.
-            map = layer.buildPathMap[moduleName] = url;
-    
+            //Save the module name to path  and path to module name mappings.
+            layer.buildPathMap[moduleName] = url;
+            layer.buildFileToModule[url] = moduleName;
+
             //Load the file contents, process for conditionals, then
             //evaluate it.
             contents = _readFile(url);
             contents = pragma.process(url, contents, context.config);
-    
+
             //Find out if the file contains a require() definition. Need to know
             //this so we can inject plugins right after it, but before they are needed,
             //and to make sure this file is first, so that require.def calls work.
@@ -127,7 +128,7 @@
             if (!layer.existingRequireUrl && parse.definesRequire(url, contents)) {
                 layer.existingRequireUrl = url;
             }
-    
+
             //Only eval complete contents if asked, or if it is a require extension.
             //Otherwise, treat the module as not safe for execution and parse out
             //the require calls.
@@ -138,12 +139,17 @@
                 //code in a require callback.
                 contents = parse(url, contents);
             }
-    
+
             if (contents) {
                 eval(contents);
 
                 //Support anonymous modules.
                 require.completeLoad(moduleName, context);
+            }
+            
+            // remember the list of dependencies for this layer - don't remember plugins
+            if (moduleName.indexOf("require/") !== 0) {
+	            layer.buildFilePaths.push(url);
             }
         }
 
@@ -165,7 +171,6 @@
     require.execCb = function (name, cb, args) {
         var url = name && layer.buildPathMap[name];
         if (url && !layer.loadedFiles[url]) {
-            layer.buildFilePaths.push(url);
             layer.loadedFiles[url] = true;
             layer.modulesWithNames[name] = true;
         }


### PR DESCRIPTION
james,

i've been a little bit bold with this patch.  i've run the tests and everything seems fine but make sure you're happy with what it does before you take it.  

and what it does is...

previously, any dependencies which did not call `define` were always included last in the layer when built.  this patch changes the behavior so that those are built in the order in which they are listed as dependencies.

fwiw,  i'm working towards using dojo (from source and built) without a conversion step.  once you've got fixes for #35 and #36 then building dojo should be possible via something like a `dojoLoader.js` file as a sibling to `require.js`
    define('dojoLoader', [
        'dojo/_base/_loader/bootstrap.js',
        'dojo/_base/_loader/loader.js',
        'dojo/_base/_loader/hostenv_browser.js',
        // this list of includes is needed because of the conditional used in dojo/_base.js
        'dojo/_base/lang',
        'dojo/_base/array',
        'dojo/_base/declare',
        'dojo/_base/connect',
        'dojo/_base/Deferred',
        'dojo/_base/json',
        'dojo/_base/Color',
        'dojo/_base/browser'
    ], function () {});

working with dojo from source requires a small little kludge to get i18n to work but apart from that i haven't found any major problems.

thanks,

ben...
