### PR TITLE
order plugin doesn't work with a build

### DIFF
--- a/require/order.js
+++ b/require/order.js
@@ -99,24 +99,27 @@
             var context = require.s.contexts[contextName],
                 url = require.nameToUrl(name, null, contextName);
 
-            //Make sure the async attribute is not set for any pathway involving
-            //this script.
-            require.s.skipAsync[url] = true;
-            if (supportsInOrderExecution) {
-                //Just a normal script tag append, but without async attribute
-                //on the script.
-                require([name], contextName);
-            } else {
-                //Credit to LABjs author Kyle Simpson for finding that scripts
-                //with type="script/cache" allow scripts to be downloaded into
-                //browser cache but not executed. Use that
-                //so that subsequent addition of a real type="text/javascript"
-                //tag will cause the scripts to be executed immediately in the
-                //correct order.
-                context.orderWaiting.push(name);
-                context.loaded[name] = false;
-                require.attach(url, contextName, name, scriptCacheCallback, "script/cache");
-            }
+            // do nothing if the module is already loaded
+            if (!context.loaded[name]){
+	            //Make sure the async attribute is not set for any pathway involving
+	            //this script.
+	            require.s.skipAsync[url] = true;
+	            if (supportsInOrderExecution) {
+	                //Just a normal script tag append, but without async attribute
+	                //on the script.
+	                require([name], contextName);
+	            } else {
+	                //Credit to LABjs author Kyle Simpson for finding that scripts
+	                //with type="script/cache" allow scripts to be downloaded into
+	                //browser cache but not executed. Use that
+	                //so that subsequent addition of a real type="text/javascript"
+	                //tag will cause the scripts to be executed immediately in the
+	                //correct order.
+	                context.orderWaiting.push(name);
+	                context.loaded[name] = false;
+	                require.attach(url, contextName, name, scriptCacheCallback, "script/cache");
+	            }
+           }
         },
 
         /**
@@ -136,7 +139,7 @@
 
         /**
          * Called when all modules have been loaded. Not needed for this plugin.
-         * State is reset as part of scriptCacheCallback. 
+         * State is reset as part of scriptCacheCallback.
          */
         orderDeps: function (context) {
         }


### PR DESCRIPTION
i'm having a problem with using the order plugin in a build.  the problem is resolved if i wrap the `load` logic in an `if (!context.loaded[name])` eg
    if (!context.loaded[name]) {
        if (supportsInOrderExection) {
            // ...
        } else {
            // ...
        }
    }

the reason this works is because after building, i have something like:
    define('one.js', function () {
        return { module: 'one' };
    });
    define('two.js', function () {
        return { module: 'two' };
    });
    define('three', ['order!one.js', 'order!two.js'], function (one, two) {
        return { module: 'three'};
    });

`require.checkDeps` will try to load `one.js` and `two.js` because it's checking if `context.specified[dep.fullName]` is specfied and for `order!one.js` and `order!two.js` they have not been specified.  however, `one.js` and `two.js` will be loaded (`context.loaded[name]` is `true`) and so there should be no need to add these scripts.

this patch resolves that issue but is there a better way to do this or is this the right way?
