### PR TITLE
include plugin during sync call to require

### DIFF
--- a/require.js
+++ b/require.js
@@ -845,6 +845,17 @@ var require, define;
             }, config);
         }
 
+        function callPluginSync(moduleMap) {
+            var ret; // this will be the return value
+
+            plugins[moduleMap.prefix].load(moduleMap.name, makeRequire(moduleMap.parentMap, true),
+            function (value) {
+                ret = value;
+            });
+
+            return ret;
+        }
+
         function loadPaused(dep) {
             //Renormalize dependency if its name was waiting on a plugin
             //to load, which as since loaded.
@@ -1082,7 +1093,7 @@ var require, define;
                     //Normalize module name, if it contains . or ..
                     moduleMap = makeModuleMap(moduleName, relModuleMap);
 
-                    ret = defined[moduleMap.fullName];
+                    ret = defined[moduleMap.fullName] || callPluginSync(moduleMap);
                     if (ret === undefined) {
                         return req.onError(new Error("require: module name '" +
                                     moduleMap.fullName +


### PR DESCRIPTION
this is one way that plugins could be called during a sync call to require.  maybe this is not the ultimate way to make this happen.  for example, it might be nice to have a way to indicate to a plugin that this is a sync call.  at least this might help get things moving for this to happen.

the first commit also provides a way to redefine the text, i18n and order plugins that requirejs gives special treatment to.
