### PR TITLE
Node shim fix

### DIFF
--- a/adapt/node.js
+++ b/adapt/node.js
@@ -53,7 +53,7 @@
     };
 
     require.load = function (context, moduleName, url) {
-        var contents;
+        var contents, sandbox;
 
         //isDone is used by require.ready()
         require.s.isDone = false;
@@ -64,7 +64,14 @@
 
         if (path.existsSync(url)) {
             contents = fs.readFileSync(url, 'utf8');
-            vm.runInThisContext(contents, url);
+            sandbox = vm.createContext();
+            Object.getOwnPropertyNames(global).forEach(function (prop) {
+                sandbox[prop] = global[prop];
+            });
+            sandbox.require = require;
+            sandbox.__filename = fs.realpathSync(url);
+            sandbox.__dirname = path.dirname(sandbox.__filename);
+            vm.runInNewContext(contents, sandbox, url);
         } else {
             define(function () {
                 return req(moduleName);


### PR DESCRIPTION
After digging around, trying to figure out #83, I am now 100% positive that the problem is using `vm.runInThisContext` instead of bootstrapping a new context and using `vm.runInNewContext`. I ran in to another bug caused by using `vm.runInThisContext` today as well: the globals `__dirname` and `__filename` are incorrectly assigned as well.

Attached is a commit which will bootstrap a new context for the new module being loaded and then use `vm.runInNewContext` with it.

I think that after this and my other pull request about "this" in module defining functions get merged in to master, requirejs's node support will be leaps and bounds ahead of where it is now. Yay! :)
