### PR TITLE
Fix for issue 82: Stack overflow due too much recursion on IE in certain cases.

### DIFF
--- a/require.js
+++ b/require.js
@@ -810,7 +810,8 @@ var require, define;
                     forceExec(manager, {});
                 }
 
-                checkLoaded();
+                // Break out of recursion by using immediate timeout
+                setTimeout(checkLoaded, 0);
                 return undefined;
             }
 


### PR DESCRIPTION
IE bails out due to not enough stack space when checkLoaded keeps calling itself after processing the wait array. Other browsers are more tolerant, or probably do not exhibit this much recursion due to a difference in the order of events.

First tried converting this tail recursion into a loop. That fixed the stack overflow, but due to the busy loop it created, it caused the browser to become unresponsive every 4-5 refreshes.

Breaking the recursion by making the call to checkLoaded asynchronous through the use of a dummy timeout has helped. I no longer experience any stack overflows or busy loops on IE.
