### PR TITLE
Changed the return value of trivially wrapped modules

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -665,7 +665,7 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
             //after the module is processed.
             //If we have a name, but no defined module, then add in the placeholder.
             if (moduleName && !layer.modulesWithNames[moduleName] && !config.skipModuleInsertion) {
-                fileContents += 'define("' + moduleName + '", function(){});\n';
+                fileContents += 'define("' + moduleName + '", function(){return true;});\n';
             }
         }
 


### PR DESCRIPTION
The wrapper function included in build.js adds 'function(){}' as the callback in define. This returns 'undefined', so later checks (in defined[] in require.js) also return undefined. Unless I'm mistaken :)
