### PR TITLE
Allow overriding of RequireJS error handling

### DIFF
--- a/require.js
+++ b/require.js
@@ -76,7 +76,13 @@ var requirejs, require, define;
      * @returns {Error}
      */
     function makeError(id, msg, err) {
-        var e = new Error(msg + '\nhttp://requirejs.org/docs/errors.html#' + id);
+        var e = new Error(msg + '\nhttp://requirejs.org/docs/errors.html#' + id),
+            handleErrors = ctx.config.handleErrors;
+
+        if( handleErrors != null && ! handleErrors ){
+            throw err;
+        }
+
         if (err) {
             e.originalError = err;
         }


### PR DESCRIPTION
Allow overriding of handled errors, discussion on issue #116.  

Setting handleErrors to false throws the original error.  This prevents side effects when copying error objects, like browser's link to meta information about the error.  Throwing the original error prevents these issues on runtime errors like ReferenceErrors, Left-side Assignment and possibly others.

Usage:

```
require({

    handleErrors: false //default true
})
```

Resolves #116
