### PR TITLE
Run at require-time configuration options

### DIFF
--- a/require.js
+++ b/require.js
@@ -1386,7 +1386,11 @@ var requirejs, require, define;
                     for (i = syms.length; i > 0; i--) {
                         parentModule = syms.slice(0, i).join("/");
                         if (paths[parentModule]) {
-                            syms.splice(0, i, paths[parentModule]);
+                            if(isFunction(paths[parentModule])) {
+                                syms.splice(0, i, paths[parentModule]());
+                            } else {
+                                syms.splice(0, i, paths[parentModule]);
+                            }
                             break;
                         } else if ((pkg = pkgs[parentModule])) {
                             //If module name is just the package name, then looking


### PR DESCRIPTION
If a function is passed instead of a string as a defined path, run the
function only at time of requirement to get the path. This allows for
deprecated paths which can still be bundled and minified, which won't
spit an error the moment the bundle as a whole is loaded.
