### PR TITLE
Text plugin "canUseHxr()" fix when triggered w/o  "protocol", "hostname" and "port" params

### DIFF
--- a/text.js
+++ b/text.js
@@ -180,6 +180,14 @@
                 if (!match) {
                     return true;
                 }
+                
+                if( typeof location !=='undefined' && location.hostname )
+                {
+                  protocol = protocol || location.protocol.substr( 0, location.protocol.length-1) ;
+                	hostname = hostname || location.hostname ;
+                	port = port || location.port ;
+                }                
+                
                 uProtocol = match[2];
                 uHostName = match[3];
 
@@ -189,7 +197,7 @@
 
                 return (!uProtocol || uProtocol === protocol) &&
                        (!uHostName || uHostName === hostname) &&
-                       ((!uPort && !uHostName) || uPort === port);
+                       (!uPort || uPort === port);
             },
 
             finishLoad: function (name, strip, content, onLoad, config) {


### PR DESCRIPTION
Text plugin : let's use "protocol", "hostname" and "port" params in "canUseHxr()" function when : 1) these params are undefined 2) we can retrieve their value from the "location" object of the browser.
