### PR TITLE
check if the browser supports cross domain XHR

### DIFF
--- a/text.js
+++ b/text.js
@@ -183,6 +183,11 @@
              * @returns Boolean
              */
             useXhr: function (url, protocol, hostname, port) {
+                if (typeof XMLHttpRequest !== "undefined") {
+                    if ("withCredentials" in new XMLHttpRequest()) {
+                        return true;
+                    }
+                }
                 var match = text.xdRegExp.exec(url),
                     uProtocol, uHostName, uPort;
                 if (!match) {


### PR DESCRIPTION
With this fix I can successfully put my files on a different domain as long as the server sends the CORS headers.
