### PR TITLE
a quick fix to safely determine if attachEvent is natively supported 

### DIFF
--- a/require.js
+++ b/require.js
@@ -7,7 +7,7 @@
 /*global window, navigator, document, importScripts, jQuery, setTimeout, opera */
 
 var requirejs, require, define;
-(function () {
+(function (undefined) {
     //Change this version number for each release.
     var version = "1.0.7",
         commentRegExp = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg,


### PR DESCRIPTION
1.a quick fix to safely determine if attachEvent is natively supported  
(https://github.com/jrburke/requirejs/issues/187)
2. make 'undefined' became local variable to prevent error when 'undefined' is accidentally overwitten.
