### PR TITLE
comment and regex fix

### DIFF
--- a/require.js
+++ b/require.js
@@ -1481,6 +1481,7 @@ var requirejs, require, define;
                 //If a colon is in the URL, it indicates a protocol is used and it is just
                 //an URL to a file, or if it starts with a slash, contains a query arg (i.e. ?)
                 //or ends with .js, then assume the user meant to use an url and not a module id.
+                //An exception is made for '.json?', for which the query arg will be ignored.
                 //The slash is important for protocol-less URLs as well as full paths.
                 if (req.jsExtRegExp.test(moduleName)) {
                     //Just a plain path, not module name lookup, so just return it.
@@ -1606,7 +1607,7 @@ var requirejs, require, define;
     req.version = version;
 
     //Used to filter out dependencies that are already paths.
-    req.jsExtRegExp = /^\/|:|\?|\.js$/;
+    req.jsExtRegExp = /^\/|:|^(?!.*\.json\?).*\?|\.js$/;
     s = req.s = {
         contexts: contexts,
         //Stores a list of URLs that should not get async script tag treatment.


### PR DESCRIPTION
Two changes:

First elaborates on the comment about parsing url's/module names.

The second is a regex change that adds an exception for when a `?` is preceded by `.json`, so it is treated as a module and not a url. This is so JSONP requests can still follow the module `baseUrl` rules.
