### PR TITLE
Public function to update the included URL

### DIFF
--- a/require.js
+++ b/require.js
@@ -1518,6 +1518,10 @@ var requirejs, require, define;
                     url = syms.join("/") + (ext || ".js");
                     url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? "" : config.baseUrl) + url;
                 }
+                //Give an option to the users to make a final change to the url
+                if(typeof config.urlFilter === "function"){
+                    url = config.urlFilter(url);
+                }
 
                 return config.urlArgs ? url +
                                         ((url.indexOf('?') === -1 ? '?' : '&') +


### PR DESCRIPTION
Added a function to allow users a last chance to modify the resource that is being included. The function is defined in the require.config as urlFilter.

I know it's not the most elegant solution, but I couldn't find any other way to do it. I tried creating a plugin, but then I'd have to call it on every single require/define call.

In my case, the url of the files on my development environment are different than the url of the files in production environment: i.e.: 
development = /assets/js/main.js
production = /assets/js/main.min.js.gz (minified and compressed)

If my solution is not valid, what would you suggest?

Thanks!
