### PR TITLE
Fallback on main if package name not given.

### DIFF
--- a/require.js
+++ b/require.js
@@ -1301,17 +1301,18 @@ var requirejs, require, define;
                 //Adjust packages if necessary.
                 if (cfg.packages) {
                     each(cfg.packages, function (pkgObj) {
-                        var location;
+                        var location, name;
 
                         pkgObj = typeof pkgObj === 'string' ? { name: pkgObj } : pkgObj;
+                        name = pkgObj.name || pkgObj.main;
                         location = pkgObj.location;
 
                         //Create a brand new object on pkgs, since currentPackages can
                         //be passed in again, and config.pkgs is the internal transformed
                         //state for all package configs.
-                        pkgs[pkgObj.name] = {
-                            name: pkgObj.name,
-                            location: location || pkgObj.name,
+                        pkgs[name] = {
+                            name: name,
+                            location: location || name,
                             //Remove leading dot in main, so main paths are normalized,
                             //and remove any trailing .js, since different package
                             //envs have different conventions: some use a module name,

--- a/tests/packages/bat/0.2/bat.js
+++ b/tests/packages/bat/0.2/bat.js
@@ -1,0 +1,4 @@
+define({
+    name: 'bat',
+    version: '0.2'
+});

--- a/tests/packages/packages-tests.js
+++ b/tests/packages/packages-tests.js
@@ -44,15 +44,19 @@ require({
                 name: 'dojox/window',
                 location: 'dojox/window',
                 main: 'window'
+            },
+            {
+                main: 'bat',
+                location: 'bat/0.2'
             }
         ]
     },
        ["require", "alpha", "alpha/replace", "beta", "beta/util", "bar", "baz",
         "foo", "foo/second", "dojox/chair", "dojox/table", "dojox/door", "dojox/window/pane",
-        "dojox/window", "dojox/table/legs", "funky"],
+        "dojox/window", "dojox/table/legs", "funky", "bat"],
 function(require,   alpha,   replace,         beta,   util,        bar,   baz,
          foo,   second,       chair,         table,         door,         pane,
-         window,         legs,               funky) {
+         window,         legs,               funky, bat) {
     var dataUrl = require.toUrl('foo/../data.html');
     doh.register(
         "packages",
@@ -83,6 +87,8 @@ function(require,   alpha,   replace,         beta,   util,        bar,   baz,
                 t.is('dojox/window/pane', window.paneName);
                 t.is('funky', funky.name);
                 t.is('monkey', funky.monkeyName);
+                t.is('bat', bat.name);
+                t.is('0.2', bat.version);
             }
         ]
     );


### PR DESCRIPTION
It's fairly common for browser-targeted packages and libraries to use the package name as the filename for the main script. For example, jQuery uses the filename `jquery.js` rather than `main.js`. Falling back on the `main` parameter of a package configuration when `name` is not specified would reduce verbosity:

``` javascript
// Original
packages: [
    'foo', // AMD
    { name: 'bar', main: 'index' }, // CommonJS
    { name: 'jquery', main: 'jquery', location: 'jquery/1.7.2/dist' } // Browser
]

// With fallback
packages: [
    'foo', // AMD
    { name: 'bar', main: 'index' }, // CommonJS
    { main: 'jquery', location: 'jquery/1.7.2/dist' } // Browser
]
```

_update:_ Reformatted the use cases to emphasize change more clearly.
