### PR TITLE
Checks that depMap exists before doing anything with it.

### DIFF
--- a/require.js
+++ b/require.js
@@ -842,23 +842,25 @@ var requirejs, require, define;
                                                true);
                         this.depMaps.push(depMap);
                     }
-
-                    var handler = handlers[depMap.id];
-
-                    if (handler) {
-                        this.depExports[i] = handler(this);
-                        return;
-                    }
-
-                    this.depCount += 1;
-
-                    on(depMap, 'defined', bind(this, function (depExports) {
-                        this.defineDep(i, depExports);
-                        this.check();
-                    }));
-
-                    if (errback) {
-                        on(depMap, 'error', errback);
+                    
+                    if (depMap) {
+                        var handler = handlers[depMap.id];
+    
+                        if (handler) {
+                            this.depExports[i] = handler(this);
+                            return;
+                        }
+    
+                        this.depCount += 1;
+    
+                        on(depMap, 'defined', bind(this, function (depExports) {
+                            this.defineDep(i, depExports);
+                            this.check();
+                        }));
+    
+                        if (errback) {
+                            on(depMap, 'error', errback);
+                        }
                     }
                 }));
 


### PR DESCRIPTION
This is just a 2 line fix, that checks that the variable depMap exists before interacting with it. This solves [issue #314 ](https://github.com/jrburke/requirejs/issues/314).

I've signed CLA just in case.
