### PR TITLE
data-main in a subdirectory when baseUrl already defined

### DIFF
--- a/require.js
+++ b/require.js
@@ -1924,21 +1924,21 @@ var requirejs, require, define;
             //baseUrl, if it is not already set.
             dataMain = script.getAttribute('data-main');
             if (dataMain) {
-
-                //Pull off the directory of data-main for use as the
-                //baseUrl.
-                src = dataMain.split('/');
-                mainScript = src.pop();
-                subPath = src.length ? src.join('/')  + '/' : './';
-
                 //Set final baseUrl if there is not already an explicit one.
                 if (!cfg.baseUrl) {
+                    //Pull off the directory of data-main for use as the
+                    //baseUrl.
+                    src = dataMain.split('/');
+                    mainScript = src.pop();
+                    subPath = src.length ? src.join('/')  + '/' : './';
+
                     cfg.baseUrl = subPath;
+                    dataMain = mainScript;
                 }
 
                 //Strip off any trailing .js since dataMain is now
                 //like a module name.
-                dataMain = mainScript.replace(jsSuffixRegExp, '');
+                dataMain = dataMain.replace(jsSuffixRegExp, '');
 
                 //Put the data-main script in the files to load.
                 cfg.deps = cfg.deps ? cfg.deps.concat(dataMain) : [dataMain];


### PR DESCRIPTION
Hi there,

RequireJS is great, and 2.0.2 fixes issues for me around plugins so I really need to use it.  Unfortunately it looks like changes around data-main make it impossible to put your main script in a subdirectory now if you've already manually specified your baseUrl?

For example I've got the following config:

  {
    baseUrl: '/'
  }

And my data-main="src/main" (I have other scripts in lib/ etc which I also need to reference)

Until 2.0.2 this worked fine, but since then requirejs tries to load in just /main.js instead of /src/main.js.  This seems to be because of the changes around automatically setting the baseUrl.

This pull request changes the behaviour so that the whole data-main module name is used if a baseUrl is already set by the config, I also optimised a little to avoid doing any work on the URL if baseUrl is already set.

Thanks
