### PR TITLE
API text plugin documentation patch

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -1036,7 +1036,7 @@ require(['jquery'], function ($) {
 
 <p>It is nice to build HTML using regular HTML tags, instead of building up DOM structures in script. However, there is no good way to embed HTML in a JavaScript file. The best that can be done is using a string of HTML, but that can be hard to manage, particularly for multi-line HTML.</p>
 
-<p>RequireJS has a plugin, text.js, that can help with this issue. It will automatically be loaded if the text! prefix is used for a dependency. <a href="download.html#text">Download the plugin</a> and put it in the same directory as your app's main JS file.</p>
+<p>RequireJS has a plugin, text.js, that can help with this issue. It will automatically be loaded if the text! prefix is used for a dependency. <a href="download.html#text">Download the plugin</a> and put it at the <a href="#config-baseUrl">baseUrl</a>.</p>
 
 <p>You can specify a text file resource as a dependency like so:</p>
 


### PR DESCRIPTION
I find that "same directory as your app's main JS file" to be confusing. Readers may take it to mean plugins must be at the same directory as the main JS file.
