### PR TITLE
Object.prototype.toString for type-testing rather than instanceof?

### DIFF
--- a/require.js
+++ b/require.js
@@ -38,11 +38,11 @@ var requirejs, require, define;
         interactiveScript, currentlyAddingScript, mainScript, subPath;
 
     function isFunction(it) {
-        return ostring.call(it) === '[object Function]';
+        return it instanceof Function;
     }
 
     function isArray(it) {
-        return ostring.call(it) === '[object Array]';
+        return it instanceof Array;
     }
 
     /**


### PR DESCRIPTION
That's a pattern I see regularly, but i don't grasp why it'd be done: codebases (including requirejs) tend to use the `Object.prototype.toString(o) === '[object SomeType]'` pattern when testing types rather than use the native `instanceof`, even when testing for actual object types (e.g. `Function` or `Array`), even though `instanceof` is [universally faster, even when the thing being tested has to be wrapped](http://jsperf.com/bound-object-prototype-tostring-vs-unbound/2) and expresses intent much more clearly.

The only reason I'd see is the fear of developers creating subclasses of the types being tested and that being incorrect/undesirable for some reason. Am I missing something?
