### PR TITLE
Add ability to dynamically add new shim files

### DIFF
--- a/require.js
+++ b/require.js
@@ -165,7 +165,8 @@ var requirejs, require, define;
             ['toUrl'],
             ['undef'],
             ['defined', 'requireDefined'],
-            ['specified', 'requireSpecified']
+            ['specified', 'requireSpecified'],
+            ['addShim']
         ], function (item) {
             var prop = item[1] || item[0];
             req[item[0]] = context ? makeContextModuleFunc(context[prop], relMap) :
@@ -1387,6 +1388,23 @@ var requirejs, require, define;
                         return exports.apply(global, arguments);
                     };
                 }
+            },
+            
+            addShim: function(newShim) {
+                var shim = config.shim;
+                eachProp(newShim, function (value, id) {
+                    //Normalize the structure
+                    if (isArray(value)) {
+                        value = {
+                            deps: value
+                        };
+                    }
+                    if (value.exports && !value.exports.__buildReady) {
+                        value.exports = context.makeShimExports(value.exports);
+                    }
+                    shim[id] = value;
+                });
+                config.shim = shim;
             },
 
             requireDefined: function (id, relMap) {


### PR DESCRIPTION
Add the ability to add new shim files dynamically, such that dependencies can do it as well. This allows the following case:

main.js:

```
var someCondition = ...;
var deps = [];
if (someCondition) {
    deps.push("path/to/mymodule.js");
}

require(deps, function(mymodule) {
    if (mymodule) {
        console.log(module.bar);
    }
});
```

mymodule.js:

```
require.addShim({
    "path/to/foo.js": {
        deps: [],
        exports: "foo"
    },
    "path/to/bar.js": {
        deps: ["path/to/foo"],
        exports: "bar"
    }
});

define(["path/to/bar"], function(bar) {
    return {
        bar: bar
    }
});
```

It's a bit of a contrived example, but my specific case happens when some inner dependency (which I don't know about in advance, so I can't include it in the call to `require.config`) needs some shimmed file, so I need to add it.

I'm sure this change would require more testing and comments/docs, I'm just curious what people think and whether this is acceptable at all.
