### PR TITLE
Ensure empty config is a live reference

### DIFF
--- a/require.js
+++ b/require.js
@@ -566,7 +566,8 @@ var requirejs, require, define;
                         id: mod.map.id,
                         uri: mod.map.url,
                         config: function () {
-                            return (config.config && getOwn(config.config, mod.map.id)) || {};
+                            config.config = config.config || {};
+                            return (config.config[mod.map.id] = config.config[mod.map.id] || {});
                         },
                         exports: defined[mod.map.id]
                     });


### PR DESCRIPTION
This is a first commit towards achieving https://github.com/jrburke/require-cs/pull/35

The 'createXhr' call for the text plugin works perfectly for these needs.

The only issue is that if no config is specified, the text plugin gets an empty object for config which isn't referenced on the original config object. This means that a dynamic config change on that config object won't be seen by the text plugin.

This pull request ensures that when a module asks for config and there is none, the config is set to an empty object which is properly referenced on the config object to ensure future changes reference through correctly.
