### PR TITLE
Allowing ':empty' in requirejs

### DIFF
--- a/require.js
+++ b/require.js
@@ -571,6 +571,9 @@ var requirejs, require, define;
                         exports: defined[mod.map.id]
                     });
                 }
+            },
+            ':empty': function () {
+                return null;
             }
         };
 


### PR DESCRIPTION
This would be useful for me for the following situation:

I have a module that depends on jquery, but I'd like to evaluate it on the server, and will not try and execute any of the parts of code that actually call jquery (ie it is called through function closers and not during the main definition script).

If I can simply map jquery to `:empty` then I can still evaluate this browser code.

This also solves https://github.com/jrburke/r.js/issues/222

At the moment I'm having to load a custom `empty` module as a volo dependency to support this, so this would be a lot nicer.
