### PR TITLE
NodeJS optimization error callback

### DIFF
--- a/docs/node.html
+++ b/docs/node.html
@@ -171,6 +171,8 @@ requirejs.optimize(config, function (buildResponse) {
     //included. Load the built file for the contents.
     //Use config.out to get the optimized file contents.
     var contents = fs.readFileSync(config.out, 'utf8');
+}, function(err) {
+    //optimization err callback
 });
 </code></pre>
 


### PR DESCRIPTION
This amends the 'Use with Node' section to include the NodeJS error callback within the current optimization code example.
