### PR TITLE
Add missing brace in docs/optimization.html

### DIFF
--- a/docs/optimization.html
+++ b/docs/optimization.html
@@ -193,6 +193,7 @@ require(mods);</code></pre>
 <pre><code>paths: {
     'core/jquery': {
         tabs: 'empty:'
+    }
 }
 </code></pre>
 


### PR DESCRIPTION
Just a little typo in the example in `docs/optimization.html`. I added the missing close brace.
