### PR TITLE
Character encoding problem cause test case fail

### DIFF
--- a/tests/defineDouble/defineDouble.html
+++ b/tests/defineDouble/defineDouble.html
@@ -26,7 +26,7 @@
                 bCount += 1;
             });
 
-            require(['a', 'b'], function () {
+            require(['a', 'b'], function () {
                 doh.register(
                     'defineDouble',
                     [


### PR DESCRIPTION
tests/defineDouble/defineDouble.html fails, because there is a character encoded as ISO-8859-1 `Â`, which shows in browser like:

```

            require(['a', 'b'],Â function () {
                doh.register(
                    'defineDouble',
                    [
                        function defineDouble(t){
                            t.is(1, aCount);
                            t.is(1, bCount);
                        }
                    ]
                );
                doh.run();
            });
```

I guess this stackoverflow question describe the problem:
http://stackoverflow.com/questions/1461907/html-encoding-issues-character-showing-up-instead-of-nbsp

simply delete that character in editor to fix the test case.
