### PR TITLE
Class mapping for pseudo polymorphic association

### DIFF
--- a/require.js
+++ b/require.js
@@ -704,6 +704,9 @@ var requirejs, require, define;
         // exclusions and make sure this id is OK to be mapped into 
         // the module.
         function getIsClassMappingExcluded(id) {
+            if (!config.classMapping.exclusions) {
+                return false;
+            }
             var excluded = false;
             each(config.classMapping.exclusions, function(exclusion, i) {
                 if (id.indexOf(exclusion.replace(/\*\/*/g, '')) === 0) {


### PR DESCRIPTION
Hi James - 

I'm part of a team building a secure browser-based in-vehicle system. The way we attempt to achieve the greatest security is through heavy reliance on WebWorkers to be the C in our MVC setup. The problem we run into is that we can't pass objects over the wire, we can only json-stringify when we send and json-parse when we receive. As you can imagine, this often leaves us with little in the way of the actual object we need on the receiving side. And since `eval`ing scripts would leave us with a giant hole in our security structure, that's out of the question.

The way we thought around it was in a similar vein to polymorphic association issues - if we can send a key across the wire with our string, we can rebuild the proper object on the other side. It made sense to us to do that at the requirejs level, since that's what we're using to load scripts, and it prevents us from having another Class to map associations. 

So I changed require to give us the ability to add a `__classPath` property (the map id of the Module) to our objects, so we'd instantly know what kind of object we'd be rebuilding. You receive a string on the other side of the wire, JSON.parse, see the `__classPath` property, require it and rewrap the object.

I built in a few small changes to require in order to make this work. One is just the ability to add that variable (rather than add a whole new step into the process I added it into Module.check, so it happens at the very end of the definition process). The other is the ability to add exclusions into the config. You'd add them like

``` javascript
require.config({
    baseUrl : '/foo/',
    classMapping : {
        enabled : true, // not really necessary
        exclusions : [ 'bar', 'baz', 'bop' ] // also not necessary, but there if you need them
    }
});
```

I thought I'd pass it back to you to see if you were interested in adding this functionality to the lib.
