### PR TITLE
Allow '.js' suffix in packages names

### DIFF
--- a/require.js
+++ b/require.js
@@ -1545,10 +1545,10 @@ var requirejs, require, define;
                     parentPath;
 
                 //If a colon is in the URL, it indicates a protocol is used and it is just
-                //an URL to a file, or if it starts with a slash, contains a query arg (i.e. ?)
-                //or ends with .js, then assume the user meant to use an url and not a module id.
+                //an URL to a file, or if it starts with a slash or contains a query arg (i.e. ?),
+                //then assume the user meant to use an url and not a module id.
                 //The slash is important for protocol-less URLs as well as full paths.
-                if (req.jsExtRegExp.test(moduleName)) {
+                if (req.pathRegExp.test(moduleName)) {
                     //Just a plain path, not module name lookup, so just return it.
                     //Add extension if it is included. This is a bit wonky, only non-.js things pass
                     //an extension, this method probably needs to be reworked.
@@ -1589,7 +1589,7 @@ var requirejs, require, define;
 
                     //Join the path parts together, then figure out if baseUrl is needed.
                     url = syms.join('/');
-                    url += (ext || (/\?/.test(url) || skipExt ? '' : '.js'));
+                    url += (ext || (/\?/.test(url) || skipExt || jsSuffixRegExp.test(url) ? '' : '.js'));
                     url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
                 }
 
@@ -1730,7 +1730,7 @@ var requirejs, require, define;
     req.version = version;
 
     //Used to filter out dependencies that are already paths.
-    req.jsExtRegExp = /^\/|:|\?|\.js$/;
+    req.pathRegExp = /^\/|:|\?/;
     req.isBrowser = isBrowser;
     s = req.s = {
         contexts: contexts,


### PR DESCRIPTION
Almost nothing is actually done but I don't want to proceed until there is certainty that such changes can be done in RequireJS.

From my point of view, there are several reasons to allow ".js" suffix:
- It will make possible to publish and install packages with ".js" suffix via [Jam](http://jamjs.org/) (rels https://github.com/caolan/jam/issues/97)
- It will bring more consistency with Node.js, packages of which may end in ".js"
- It can hardly break any existing configurations
