### PR TITLE
Rewrote jQuery.html to focus more on shim configuration (#675)

### DIFF
--- a/docs/download.html
+++ b/docs/download.html
@@ -37,17 +37,6 @@
 
 <div class="subSection">
 <h4 class="hbox">
-<a name="samplejquery">Sample RequireJS 2.1.5 + jQuery 2.0.0 project</a>
-<span class="boxFlex"></span>
-<a class="download" href="http://requirejs.org/docs/release/jquery-require/jquery2.0.0-requirejs2.1.5/jquery-require-sample.zip">Download</a>
-</h4>
-
-<p>A zip file containing a sample project that uses jQuery and RequireJS.</p>
-</div>
-
-
-<div class="subSection">
-<h4 class="hbox">
 <a name="rjs">r.js: Optimizer and Node/Rhino/xpcshell adapter</a>
 <span class="boxFlex"></span>
 <a class="download" href="http://requirejs.org/docs/release/2.1.5/r.js">Download</a>

--- a/docs/jquery.html
+++ b/docs/jquery.html
@@ -1,19 +1,18 @@
 <div id="directory" class="section">
 <h1>How to use RequireJS with jQuery</h1>
+
 <ul class="index mono">
     <li class="hbox">
-        <a href="#get">Get RequireJS</a><span class="spacer boxFlex"></span><span class="sect">&sect; 1</span>
+        <a href="#shimconfig">Example using shim config</a><span class="spacer boxFlex"></span><span class="sect">&sect; 1</span>
     </li>
     <li class="hbox">
-        <a href="#setup">Set up your HTML page</a><span class="spacer boxFlex"></span><span class="sect">&sect; 2</span>
+        <a href="#cdnconfig">Example loading jquery from a cdn</a><span class="spacer boxflex"></span><span class="sect">&sect; 2</span>
     </li>
     <li class="hbox">
-        <a href="#optimize">Feel the need for speed</a><span class="spacer boxFlex"></span><span class="sect">&sect; 3</span>
-    </li>
-    <li class="hbox">
-        <a href="#advanced">Advanced use</a><span class="spacer boxFlex"></span><span class="sect">&sect; 4</span>
+        <a href="#oldexample">The previous example with a concatenated require-jquery file</a><span class="spacer boxflex"></span><span class="sect">&sect; 3</span>
     </li>
 </ul>
+
 <p>When a project reaches a certain size, managing the script modules for a project starts to get tricky. You need to be sure to sequence the scripts in the right order, and you need to start seriously thinking about combining scripts together into a bundle for deployment, so that only one or a very small number of requests are made to load the scripts.</p>
 
 <p>You may also want to load code on the fly, after page load.</p>
@@ -21,218 +20,33 @@
 <p>RequireJS can help you manage the script modules, load them in the right order, and make it easy to combine the scripts later via the RequireJS <a href="optimization.md">optimizer</a> without needing to change your markup. It also gives you an easy way to load scripts after the page has loaded, allowing you to spread out the download size over time.</p>
 
 <p>RequireJS has a module system that lets you define well-scoped modules, but you do not have to follow that system to get the benefits of dependency management and build-time optimizations. Over time, if you start to create more modular code that needs to be reused in a few places, the module format for RequireJS makes it easy to write encapsulated code that can be loaded on the fly. It can grow with you, particularly if you want to incorporate internationalization (i18n) string bundles, to localize your project for different languages, or load some HTML strings and make sure those strings are available before executing code, or even use JSONP services as dependencies.</p>
+
+
+<div class="subSection">
+<h4 class="hbox">
+<a name="shimconfig">Example with shim config</a>
+<span class="boxFlex"></span>
+<a class="download" href="http://github.com/requirejs/example-jquery-shim">Example with jQuery and a shim config</a>
+</h4>
+<p>This example shows how to use the shim config to specify dependencies for jQuery plugins that do not call define()</p>
+</div>
+
+<div class="subSection">
+<h4 class="hbox">
+<a name="cdnconfig">Example with jQuery loaded from CDN</a>
+<span class="boxFlex"></span>
+<a class="download" href="http://github.com/requirejs/example-jquery">Example with jQuery and a shim config</a>
+</h4>
+<p>This is an example on how to load an optimize your code while loading jQuery from a CDN. Please note that this requires
+all your jQuery plugins to call define()</p>
 </div>
 
 <div class="section">
 <h2>
-<a name="get">Get RequireJS</a>
-<span class="sectionMark">&sect; 1</span>
-</h2>
-
-<p>First step is to get RequireJS:</p>
-<ul>
-    <li><a href="download.html#samplejquery">download the sample project</a>.</li>
-</ul>
-
-<p>This sample project uses a configuration in the main module, which specifies the path to jQuery. This is necessary since jQuery register itself as 
-a named module.</p>
-
-</div>
-
-<div class="section">
-<h2>
-<a name="setup">Set up your HTML page</a>
-<span class="sectionMark">&sect; 2</span>
-</h2>
-
-<p>A sample HTML page would look like this (assuming you put all your .js files in a "scripts" subdirectory, and the libraries in "scripts/libs"):</p>
-
-<pre><code>
-&lt;!DOCTYPE html&gt;
-&lt;html&gt;
-    &lt;head&gt;
-        &lt;title&gt;jQuery+RequireJS Sample Page&lt;/title&gt;
-        &lt;script data-main=&quot;scripts/main&quot; src=&quot;scripts/libs/require.js&quot;&gt;&lt;/script&gt;
-    &lt;/head&gt;
-    &lt;body&gt;
-        &lt;h1&gt;jQuery+RequireJS Sample Page&lt;/h1&gt;
-    &lt;/body&gt;
-&lt;/html&gt;
-</code></pre>
-
-<p>The data-main attribute on the script tag for require.js tells RequireJS to load the scripts/main.js file. RequireJS will load any dependency that is passed to require() without a ".js" file from the same directory as the one used for data-main. If you feel more comfortable specifying the whole path, you can also do the following:</p>
-
-<pre><code>&lt;script data-main="scripts/main.js" src="scripts/libs/require.js"&gt;&lt;/script&gt;
-</code></pre>
-
-<p>What is in main.js? A call to require.config() to show where jQuery can be found. This example main.js script loads two plugins, jquery.alpha.js and jquery.beta.js (not the names of real plugins, just an example). Since those plugins aren't calling define(), we need to explain to require.js that those plugins need jQuery to be loaded first. We can specify dependencies and exports for non-AMD libraries using the 'shim' config. Since jquery.alpha and jquery.beta are just plugins that augment jQuery, they do not return modules that you can reference as function arguments.
- The plugins should be in the same directory as require.js:</p>
-
-<p>main.js:</p>
-
-<pre><code>
-require.config({
-  "paths": {
-    // this is the only place where you point to the actual location
-    // of the jquery file. For the rest, only use the module name, which is "jquery"
-    // the reason we need to do this is that jQuery loads as a named module:
-    // define("jquery", [], function() { return jQuery; });
-    "jquery": "libs/jquery"
-  },
-  "shim": {
-    "libs/jquery.alpha": ["jquery"],
-    "libs/jquery.beta": ["jquery"]
-  }
-});
-  
-
-define(["jquery", "jquery.alpha", "jquery.beta"], function($) {
-    //the jquery.alpha.js and jquery.beta.js plugins have been loaded.
-    $(function() {
-        $('body').alpha().beta();
-    });
-});
-</code></pre>
-</div>
-
-<div class="section">
-<h2>
-<a name="optimize">Feel the need for speed</a>
+<a name="oldexample">The previous example with a concatenated require-jquery file</a>
 <span class="sectionMark">&sect; 3</span>
 </h2>
-
-<p>Now your page is set up to be optimized very easily via the <a href="optimization.html">optimizer</a>.</p>
-
-<p>If you downloaded the jQuery sample project, then the optimizer that is part of the RequireJS source is already included.</p>
-
-<p>If you are not using the jQuery sample project, get the optimizer by downloading the <a href="download.html#rjs">r.js file</a> and place it anywhere you like outside your web development area.</p>
-
-<p>For the purposes of this example, the RequireJS source is placed as a sibling to the <strong>webapp</strong> directory, which contains the HTML page and the scripts directory with all the scripts. Complete directory structure:</p>
-
-<ul>
-<li>r.js  (the file that includes the optimizer)</li>
-<li>webapp/app.html</li>
-<li>webapp/scripts/main.js</li>
-<li>webapp/scripts/libs/require.js</li>
-<li>webapp/scripts/libs/jquery.js</li>
-<li>webapp/scripts/libs/jquery.alpha.js</li>
-<li>webapp/scripts/libs/jquery.beta.js</li>
-</ul>
-
-<p> Then, in the scripts directory that has main.js, create a file called app.build.js with the following contents: </p>
-
-<pre><code>({
-    appDir: "../",
-    baseUrl: "scripts",
-    dir: "../../webapp-build",
-
-    // instead of re-typing the shim config and paths from the main file,
-    // we can tell r.js to look for the first require.config call in our main.js:
-    mainConfigFile: "main.js", 
-    name: "main",
-
-    //Comment out the optimize line if you want
-    //the code minified by UglifyJS.
-    optimize: "none"
-})</code></pre>
-
-<p>To use the optimizer, you need <a href="http://nodejs.org">Node</a> or Java 6 installed. These instructions assume Node is being used. See the <a href="optimization.html">Optimization page</a> for more information.</p>
-
-<p>To start the build, go to the <strong>webapp/scripts</strong> directory, execute the following command:</p>
-
-<pre><code>node ../../r.js -o app.build.js
-</code></pre>
-
-<p>Now, in the webapp-build directory, main.js will have the main.js contents, jquery.js, jquery.alpha.js and jquery.beta.js inlined. If you then load the app.html file in the webapp-build directory, you should not see any network requests for jquery.js, jquery.alpha.js and jquery.beta.js.</p>
-</div>
-
-
-<div class="section">
-<h2>
-<a name="advanced">Advanced use: Loading jQuery from CDN</a>
-<span class="sectionMark">&sect; 4</span>
-</h2>
-
-<p>The steps above make it easy start modular development with jQuery, particularly if you are using jQuery plugins that assume jQuery is already loaded in the page.  The trade-off with the above approach is that you have to include jQuery in your built file.
+<p>
+Previously, we've been pointing to an example using a special require-jquery file, which consisted of require.js and jQuery concatenated. This is no longer the recommended way to use jQuery with require.js, but if you're looking for the (no longer maintained) example, [you can find require-jquery here](https://github.com/jrburke/require-jquery).
 </p>
-
-<p>Ideally you would not need to include jQuery in the built product, and just use RequireJS to load jQuery on demand from a CDN, to raise the chances of the user hitting the browser cache. This currently does not work with the shim config, however if we modify the plugins to call define(), we can exclude jQuery from the build and load jQuery from CDN:</p>
-
-<p>jquery.alpha.amd.js:</p>
-<pre><code>
-define(["jquery"], function($) {
-    $.fn.alpha = function() {
-        return this.append('&lt;p&gt;Alpha is Go!&lt;/p&gt;');
-    };
-});
-</code></pre>
-
-<p>jquery.beta.amd.js:</p>
-<pre><code>
-define(["jquery"], function($) {
-    $.fn.beta = function() {
-        return this.append('&lt;p&gt;Beta is Go!&lt;/p&gt;');
-    };
-});
-</code></pre>
-
-<p>cdn.build.js:</p>
-<pre><code>
-({
-    appDir: "../",
-    baseUrl: "scripts",
-    dir: "../../webapp-build",
-    optimize: "none",
-    // point to path config in main.amd
-    // jQuery is automatically excluded
-    // because the path points to a network URL
-    mainConfigFile: "main.amd.js",
-    modules: [
-        {
-            name: "main.amd"
-        }
-    ]
-})
-</code></pre>
-
-<p>main.amd.js:</p>
-<pre><code>
-require.config({
-  "paths": {
-    "jquery": "//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min"
-  }
-});
-  
-define(["jquery", "libs/jquery.alpha.amd", "libs/jquery.beta.amd"], function($) {
-    //the jquery.alpha.js and jquery.beta.js plugins have been loaded.
-    $(function() {
-        $('body').alpha().beta();
-    });
-});
-</code></pre>
-
-<p>Create an app.amd.html, which is the same as app.html, just one line differ:</p>
-<pre><code>&lt;script data-main=&quot;scripts/main.amd&quot; src=&quot;scripts/libs/require.js&quot;&gt;&lt;/script&gt;
-</code></pre>
-
-<p>Now, on the command line, run:</p>
-<pre><code>node ../../r.js -o app.build.js
-</code></pre>
-
-<p>When you load app.amd.html from the webapp-build directory, you should see how 
-jQuery is loaded from the Google CDN.</p>
-
-<p>Ideally all the jQuery plugins you use would optionally call define() to register
-as a module. Some of the plugins you use may already call define() to register as an
-AMD module. If they do not, then you can wrap the code yourself with this wrapper:
-
-<pre><code>define(['jquery'], function ($) {
-    //Plugin code goes here.
-});
-</code></pre>
-
-<p>In addition, you can ask the plugin author to optionally calling define()
-in their code. The <a href="https://github.com/umdjs/umd">umdjs project</a>
-has some resources and examples to help them.</p>
-
 </div>


### PR DESCRIPTION
Hi!
Saw issue #675 about re-writing the documentation for jQuery + require.js to use the shim config instead.

This pull request changes jQuery.html to contain an example of how to use the shim config for dev and for building, and also shows a more advanced alternative where jQuery is excluded from the built product and loaded from a CDN.

I still think the require-jquery example make sense, and I've created an updated version of it here: https://github.com/karlwestin/require-jquery/tree/fix-jquery-documentation

I'd be happy to take feedback and change stuff :)
