### PR TITLE
Add RequireJS license & other info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,21 @@
 {
+    "name"          : "RequireJS",
+    "version"       : "2.1.5",
+    "description"   : "A Javascript Module Loader",
+    "url"           : "http://requirejs.org/",
+    "author"        : "James Burke",
+    "main"          : "require.js",
     "volo": {
         "url": "https://raw.github.com/jrburke/requirejs/{version}/require.js"
     },
-    "main": "require.js"
+    "licenses": [
+        {
+            "type": "BSD",
+            "url": "https://github.com/jrburke/requirejs/blob/master/LICENSE"
+        },
+        {
+            "type": "MIT",
+            "url": "https://github.com/jrburke/requirejs/blob/master/LICENSE"
+        }
+    ]
 }


### PR DESCRIPTION
NPM spec allows for the RequireJS license, author, etc in the package.json, so for completeness, I added it in :)

https://npmjs.org/doc/json.html
