### PR TITLE
Adding a config option to set an onError function

### DIFF
--- a/require.js
+++ b/require.js
@@ -1292,6 +1292,11 @@ var requirejs, require, define;
                     config.shim = shim;
                 }
 
+                //Insert custom onError
+                if (cfg.onError && typeof cfg.onError === 'function') {
+                    req.onError = cfg.onError;
+                }
+
                 //Adjust packages if necessary.
                 if (cfg.packages) {
                     each(cfg.packages, function (pkgObj) {


### PR DESCRIPTION
I've made a small modification, enabling the config object to carry a custom error handler, equivalent to setting `requirejs.onError` after RequireJS has been initialized. This way, when using the global configuration variable, there is no need to then, after including RequireJS, also set an error handler. It can all be done in one place.
