### PR TITLE
Do not add .js for paths config with querystring (hashtags too)

### DIFF
--- a/require.js
+++ b/require.js
@@ -1609,7 +1609,7 @@ var requirejs, require, define;
 
                     //Join the path parts together, then figure out if baseUrl is needed.
                     url = syms.join('/');
-                    url += (ext || (/\?/.test(url) || skipExt ? '' : '.js'));
+                    url += (ext || (/[\?#]/.test(url) || skipExt ? '' : '.js'));
                     url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
                 }
 


### PR DESCRIPTION
Related to https://github.com/jrburke/requirejs/issues/394

On top of '?', the url is tested for hashtags '#'. 
The use of hashtags allow passing parameters while preserving client-side cacheability of the js file.
