### PR TITLE
Ability to load config module through data-config attribute

### DIFF
--- a/require.js
+++ b/require.js
@@ -1909,6 +1909,52 @@ var requirejs, require, define;
         return interactiveScript;
     }
 
+    //Look for a data-config script attribute, which could also adjust the baseUrl.
+    if (isBrowser) {
+        //Figure out baseUrl. Get it from the script tag with require.js in it.
+        eachReverse(scripts(), function (script) {
+            //Set the 'head' where we can append children by
+            //using the script's parent.
+            if (!head) {
+                head = script.parentNode;
+            }
+
+            //Look for a data-config attribute to set main script for the page
+            //to load. If it is there, the path to data main becomes the
+            //baseUrl, if it is not already set.
+            dataConfig = script.getAttribute('data-config');
+            if (dataConfig) {
+                //Preserve dataConfig in case it is a path (i.e. contains '?')
+                mainScript = dataConfig;
+
+                //Set final baseUrl if there is not already an explicit one.
+                if (!cfg.baseUrl) {
+                    //Pull off the directory of data-config for use as the
+                    //baseUrl.
+                    src = mainScript.split('/');
+                    mainScript = src.pop();
+                    subPath = src.length ? src.join('/')  + '/' : './';
+
+                    cfg.baseUrl = subPath;
+                }
+
+                //Strip off any trailing .js since mainScript is now
+                //like a module name.
+                mainScript = mainScript.replace(jsSuffixRegExp, '');
+
+                 //If mainScript is still a path, fall back to dataConfig
+                if (req.jsExtRegExp.test(mainScript)) {
+                    mainScript = dataConfig;
+                }
+
+                //Put the data-config script in the files to load.
+                cfg.deps = cfg.deps ? cfg.deps.concat(mainScript) : [mainScript];
+
+                return true;
+            }
+        });
+    }
+
     //Look for a data-main script attribute, which could also adjust the baseUrl.
     if (isBrowser) {
         //Figure out baseUrl. Get it from the script tag with require.js in it.


### PR DESCRIPTION
When using requirejs with multiple pages, it is often helpful to place the requirejs.config paths and shims in a separate module in order to be share amongst all the pages.

This is what I have been doing so far:

``` html
<script src="require.js"></script>

<script>
  require(["config"], function() {
    require(["main"], function() {
    })
  });
</script>
```

After doing it this way for a while, I thought it would be cleaner to do it this way instead:

``` html
<script data-config="config-module" data-main="main-module" src="require.js"></script>
```

I didn't spend much time on this yet, I basically duplicated the section in the code that handles the data-main attribute and renamed the attributes to data-config. 
