### PR TITLE
added extra logic to handle IE 6-8 onload script

### DIFF
--- a/require.js
+++ b/require.js
@@ -1642,11 +1642,14 @@ var requirejs, require, define;
              * that was loaded.
              */
             onScriptLoad: function (evt) {
+		//this pointer has readyState which will be sent by IE6-8.
+		evt = evt || this;
                 //Using currentTarget instead of target for Firefox 2.0's sake. Not
                 //all old browsers will be supported, but this one was easy enough
                 //to support and still makes sense.
                 if (evt.type === 'load' ||
-                        (readyRegExp.test((evt.currentTarget || evt.srcElement).readyState))) {
+                        ((evt.currentTarget || evt.srcElement) && readyRegExp.test((evt.currentTarget || evt.srcElement).readyState))) ||
+			(onReadyExp.test(evt.readyState)) {
                     //Reset interactive script so a script node is not held onto for
                     //to long.
                     interactiveScript = null;


### PR DESCRIPTION
Working on side project and I noticed that IE6-8 don't send event to onreadystatechange function. They update the `this` pointer. what I did was added extra logic to check that as well.
