### PR TITLE
Don't resolve paths twice with plug-ins

### DIFF
--- a/require.js
+++ b/require.js
@@ -959,8 +959,7 @@ var requirejs, require, define;
 
                         //prefix and name should already be normalized, no need
                         //for applying map config again either.
-                        normalizedMap = makeModuleMap(map.prefix + '!' + name,
-                                                      this.map.parentMap);
+                        normalizedMap = makeModuleMap(map.prefix + '!' + name, null);
                         on(normalizedMap,
                             'defined', bind(this, function (value) {
                                 this.init([], function () { return value; }, null, {


### PR DESCRIPTION
In case of a file loaded by a plug-in (text.js or i18n.js) the relative path was wrongly resolved. Instead of set the 'parentMap' parameter again for 'makeModuleMap', just 'null' is passed since the path is already correctly resolved.
