### PR TITLE
requirejs stops loading any modules after timeout error

### DIFF
--- a/require.js
+++ b/require.js
@@ -688,6 +688,7 @@ var requirejs, require, define;
                 //If wait time expired, throw error of unloaded modules.
                 err = makeError('timeout', 'Load timeout for modules: ' + noLoads, null, noLoads);
                 err.contextName = context.contextName;
+                inCheckLoaded = false;
                 return onError(err);
             }
 


### PR DESCRIPTION
The problem is that if there was a timeout error on some script, no modules will ever load until page refresh. This strange behaviour occurs, because the `inCheckLoaded variable` is not set to false in case of error.
