### PR TITLE
Add config.define option

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -803,6 +803,16 @@ some modules to load asynchronously as part of a config block.</p>
 
 <p id="config-scriptType"><strong><a href="#config-baseUrl">scriptType</a></strong>: Specify the value for the type="" attribute used for script tags inserted into the document by RequireJS. Default is "text/javascript". To use Firefox's JavaScript 1.8 features, use "text/javascript;version=1.8".</p>
 
+<p id="config-define"><strong><a href="#config-define">define</a></strong>: Pre-define modules.  This forces requirejs to define modules to a static value at config time. This can be useful when creating contexts to use as a sandboxed requirejs environment.
+
+<pre><code>requirejs.config({
+    define: {
+        a: { foo: "bar" },
+        b: "module content"
+    }
+});
+</code></pre>
+
 </div>
 
 <div class="section">

--- a/require.js
+++ b/require.js
@@ -1292,6 +1292,13 @@ var requirejs, require, define;
                     config.shim = shim;
                 }
 
+                //Handle predefined modules
+                if (cfg.define) {
+                    eachProp(cfg.define, function(value, id) {
+                        defined[id] = value;
+                    });
+                }
+
                 //Adjust packages if necessary.
                 if (cfg.packages) {
                     each(cfg.packages, function (pkgObj) {

--- a/tests/all.js
+++ b/tests/all.js
@@ -14,6 +14,7 @@ doh.registerUrl("urlArgsToUrl", "../urlArgsToUrl.html");
 
 doh.registerUrl("config", "../config.html");
 doh.registerUrl("configRequirejs", "../configRequirejs.html");
+doh.registerUrl("configDefine", "../configDefine/configDefine.html");
 doh.registerUrl("dataMain", "../dataMain/dataMain.html");
 doh.registerUrl("dataMainIndex", "../dataMain/dataMainIndex/dataMainIndex.html");
 doh.registerUrl("dataMainBaseUrl", "../dataMain/baseUrl/dataMainBaseUrl.html");

--- a/tests/configDefine/configDefine.html
+++ b/tests/configDefine/configDefine.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: config.define Test</title>
+    <script type="text/javascript" src="../../require.js"></script>
+    <script type="text/javascript" src="../doh/runner.js"></script>
+    <script type="text/javascript" src="../doh/_browserRunner.js"></script>
+    <script type="text/javascript">
+    require({
+            baseUrl: "./",
+            define: {
+                "a": { foo: "bar" },
+                "b": function() { return "baz"; }
+            }
+        },
+        ["lamp", "a", "b"],
+        function(lamp, a, b) {
+            doh.register(
+                "configRequire",
+                [
+                    function configRequire(t) {
+                        t.is("blue", lamp.color);
+                        t.is("bar", a.foo);
+                        t.is("baz", b());
+                    }
+                ]
+            );
+            doh.run();
+        }
+    );
+    </script>
+</head>
+<body>
+    <h1>require.js: paths Test</h1>
+    <p>Tests for modules defined using the 'define' config key</p>
+    <p>Check console for messages</p>
+</body>
+</html>

--- a/tests/configDefine/lamp.js
+++ b/tests/configDefine/lamp.js
@@ -1,0 +1,3 @@
+define("lamp", {
+    color: "blue"
+});


### PR DESCRIPTION
This commit adds support for a `define` requirejs config option. This option enables pre-defining module values at config time.

``` javascript
requirejs.config({
    define: {
        fooModule: { foo: "bar" }
    }
});
```

This is a very simple implementation. It mainly addresses the need I had to pre-define module in requirejs context to use as a namespaced/sandboxed environment as described in [this thread](https://groups.google.com/forum/#!topic/requirejs/TYxjcTLCISw).
