### PR TITLE
Take config.paths into account when normalizing module urls

### DIFF
--- a/require.js
+++ b/require.js
@@ -284,6 +284,9 @@ var requirejs, require, define;
                         //module. For instance, baseName of 'one/two/three', maps to
                         //'one/two/three.js', but we want the directory, 'one/two' for
                         //this normalization.
+                        if (getOwn(config.paths, baseName)) {
+                            baseParts = context.nameToUrl(baseName).split('/');
+                        }
                         normalizedBaseParts = baseParts.slice(0, baseParts.length - 1);
                     }
 

--- a/tests/all.js
+++ b/tests/all.js
@@ -77,6 +77,7 @@ doh.registerUrl("shimBasic", "../shim/basic.html");
 doh.registerUrl("shimBasicBuilt", "../shim/built/basic-built.html");
 
 doh.registerUrl("paths", "../paths/paths.html");
+doh.registerUrl("pathsRelativeModuleId", "../paths/relativeModuleId.html");
 doh.registerUrl("pathsRelativeNormalize", "../paths/relativeNormalize/relativeNormalize.html");
 
 doh.registerUrl("moduleConfig", "../moduleConfig/moduleConfig.html");

--- a/tests/paths/relativeModuleId-tests.js
+++ b/tests/paths/relativeModuleId-tests.js
@@ -11,7 +11,7 @@ require({
             [
                 function relativeModuleId(t){
                     t.is("impl/array", array.name);
-                    t.is("util", array.utilName);
+                    t.is("impl/util", array.utilName);
                 }
             ]
         );


### PR DESCRIPTION
This patch fixes the problem where a requirejs while loading a module that uses a path shortcut and has a relative dependency would normalize the path to the relative dependency as relative to baseUrl instead of the modules normalized path.

Example before (A has a local dependency `./B`):

```
require = {
    paths {
        'A': 'path/to/A'
    }
}

require(['A'], function (A) { // Uncaught Error: Script error for: dependency --> 404 on `baseUrl/B.js`
    console.log(A);
});
```

Example after (A has a local dependency `./B`):

```
require = {
    paths {
        'A': 'path/to/A'
    }
}

require(['A'], function (A) { // `./B` dependency resolves correctly to `baseUrl/path/to/B.js`
    console.log(A);
});
```

There was an [existing test case](https://github.com/jrburke/requirejs/blob/master/tests/paths/relativeModuleId-tests.js#L14) for this. But the test case was wrong, and was not even included in the test suite.

I've updated the test to match the documented behavior in the API docs and have added it back to the test suite.

All tests run successfully on my local machine.

However I can't be certain that I have covered all use cases if some are missing from the test suite.

I hope you will consider this patch. It's a very common use case for web developers using bower to include external modules and setting them up with paths. The only way to make relative dependencies work in that case was setting up the relative dependency in paths as well. This should alleviate that anti pattern.
