### PR TITLE
Don't catch load-complete errors in Web Workers

### DIFF
--- a/require.js
+++ b/require.js
@@ -1891,9 +1891,6 @@ var requirejs, require, define;
                 //only one script needs to be loaded anyway. This may need to be
                 //reevaluated if other use cases become common.
                 importScripts(url);
-
-                //Account for anonymous modules
-                context.completeLoad(moduleName);
             } catch (e) {
                 context.onError(makeError('importscripts',
                                 'importScripts failed for ' +
@@ -1901,6 +1898,9 @@ var requirejs, require, define;
                                 e,
                                 [moduleName]));
             }
+
+            //Account for anonymous modules
+            context.completeLoad(moduleName);
         }
     };
 


### PR DESCRIPTION
I've just spent an hour or so trying to figure out why my modules weren't loading, despite Chrome's Network inspector tab clearly showing that the files were requested and loaded successfully. In fact, it was a trolly try-catch implementation in require.js which has made debugging exceptionally difficult.

Previously, any errors thrown in context.completeLoad were caught by the error handler implemented for importScripts' sake. This meant that any errors, be they SyntaxError, TypeError, etc. were caught and thrown as errors suggesting that the module could not be loaded, referring to the importScripts docs info.

Now, the context.completeLoad call has been moved outside of the importScript's try-catch, leaving errors to bubble up unaltered.
