### PR TITLE
Fixed trimDot.

### DIFF
--- a/require.js
+++ b/require.js
@@ -227,8 +227,8 @@ var requirejs, require, define;
          * @param {Array} ary the array of path segments.
          */
         function trimDots(ary) {
-            var i, part;
-            for (i = 0; ary[i]; i += 1) {
+            var i, part, length = ary.length;
+            for (i = 0; i < length; i++) {
                 part = ary[i];
                 if (part === '.') {
                     ary.splice(i, 1);


### PR DESCRIPTION
I fixed problem with processing path with slash on begin or double slash inside.
Before my change trimDot convert ["path", "", "path2", "..", "file"] to ["path", "", "path2", "..", "file"] - stops loop on empty string. After my change ["path", "", "path2", "..", "file"] convert to ["path", "", "file"].
