### PR TITLE
Fix Tiny Capitalization Error In Docs

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -180,7 +180,7 @@ require( ['foo'], function( foo ) {
 
 <p>The RequireJS syntax for modules allows them to be loaded as fast as possible, even out of order, but evaluated in the correct dependency order, and since global variables are not created, it makes it possible to <a href="#multiversion">load multiple versions of a module in a page</a>.</p>
 
-<p>(If you are familiar with or are using CommonJS modules, then please also see <a href="commonjs.html">CommonJS Notes</a> for information on how the RequirejS module format maps to CommonJS modules).</p>
+<p>(If you are familiar with or are using CommonJS modules, then please also see <a href="commonjs.html">CommonJS Notes</a> for information on how the RequireJS module format maps to CommonJS modules).</p>
 
 <p>There should only be <strong>one</strong> module definition per file on disk. The modules can be grouped into optimized bundles by the <a href="optimization.html">optimization tool</a>.</p>
 


### PR DESCRIPTION
RequirejS -> RequireJS (to match the rest of the document)
