### PR TITLE
Allow RequireJS to work in an environment where `navigator` is not defined

### DIFF
--- a/require.js
+++ b/require.js
@@ -22,7 +22,7 @@ var requirejs, require, define;
         hasOwn = op.hasOwnProperty,
         ap = Array.prototype,
         apsp = ap.splice,
-        isBrowser = !!(typeof window !== 'undefined' && navigator && window.document),
+        isBrowser = !!(typeof window !== 'undefined' && typeof navigator !== 'undefined' && window.document),
         isWebWorker = !isBrowser && typeof importScripts !== 'undefined',
         //PS3 indicates loaded and complete, but need to wait for complete
         //specifically. Sequence is 'loading', 'loaded', execution,


### PR DESCRIPTION
I tried to use RequireJS in [node-webkit](https://github.com/rogerwang/node-webkit) and received errors due to `navigator` not being defined in the browser test.

This fix allows the `isBrowser` check to pass even when the `navigator` object is not present.
