### PR TITLE
List modules inside of data main file

### DIFF
--- a/tests/all.js
+++ b/tests/all.js
@@ -15,6 +15,7 @@ doh.registerUrl("urlArgsToUrl", "../urlArgsToUrl.html");
 doh.registerUrl("config", "../config.html");
 doh.registerUrl("configRequirejs", "../configRequirejs.html");
 doh.registerUrl("dataMain", "../dataMain/dataMain.html");
+doh.registerUrl("dataMainContents", "../dataMain/contents/dataMainContents.html");
 doh.registerUrl("dataMainIndex", "../dataMain/dataMainIndex/dataMainIndex.html");
 doh.registerUrl("dataMainBaseUrl", "../dataMain/baseUrl/dataMainBaseUrl.html");
 

--- a/tests/dataMain/contents/a.js
+++ b/tests/dataMain/contents/a.js
@@ -1,0 +1,9 @@
+doh.register(
+    'testShouldNotRun',
+    [
+        function testShouldNotRun(t){
+            t.assertTrue(false);
+        }
+    ]
+);
+doh.run();

--- a/tests/dataMain/contents/b.js
+++ b/tests/dataMain/contents/b.js
@@ -1,0 +1,9 @@
+doh.register(
+    'testShouldAlsoNotRun',
+    [
+        function testShouldNotRun(t){
+            t.assertTrue(false);
+        }
+    ]
+);
+doh.run();

--- a/tests/dataMain/contents/c.js
+++ b/tests/dataMain/contents/c.js
@@ -1,0 +1,9 @@
+doh.register(
+    'testShouldRun',
+    [
+        function testShouldRun(t){
+            t.assertTrue(true);
+        }
+    ]
+);
+doh.run();

--- a/tests/dataMain/contents/dataMain.js
+++ b/tests/dataMain/contents/dataMain.js
@@ -1,0 +1,2 @@
+define('a', function() {});
+define('b', function() {});

--- a/tests/dataMain/contents/dataMainContents.html
+++ b/tests/dataMain/contents/dataMainContents.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: data-main contents Test</title>
+    <script type="text/javascript" src="../../doh/runner.js"></script>
+    <script type="text/javascript" src="../../doh/_browserRunner.js"></script>
+    <script>
+    	var require = {
+            baseUrl: "./"
+        };
+    </script>
+    <script type="text/javascript" data-contents="a,b" data-main="dataMain.js" src="../../../require.js"></script>
+    <script>
+        require(['a', 'b', 'c'], function(){});
+    </script>
+</head>
+<body>
+    <h1>require.js: data-contents test</h1>
+
+    <p>Confirm that the data-contents dependency list is read by RequireJS and that those requirements are not
+    obtained twice.</p>
+
+    <p>Check console for messages</p>
+</body>
+</html>


### PR DESCRIPTION
In this PR you'll find a unit test for a new feature I would like to propose. This feature would make it possible to annotate the contents of a main script file. For example like so:

``` js
<script data-contents="a,b" data-main="dataMain.js" src="require.js"></script>
```

In this way we tell RequireJs that the `dataMain.js` file contains both `a` and `b`. This is known by RequireJs BEFORE the async call to dataMain.js is done and most of all BEFORE the execution of the rest of the page continues. Thus if a require call is made on the page to `a` or `b` we know it is already loading.

Being able to use inline `require` blocks is my primary motivation for this feature. If the contents of the main script file is annotated with it's contents this would be possible. Namely in that case no files are requested twice, thus no conflicts exist.

What do you think?
