### PR TITLE
allow attribute data-baseurl to set application baseUrl

### DIFF
--- a/require.js
+++ b/require.js
@@ -36,7 +36,8 @@ var requirejs, require, define;
         contexts = {},
         cfg = {},
         globalDefQueue = [],
-        useInteractive = false;
+        useInteractive = false,
+        dataBaseUrl;
 
     function isFunction(it) {
         return ostring.call(it) === '[object Function]';
@@ -1959,6 +1960,16 @@ var requirejs, require, define;
                 cfg.deps = cfg.deps ? cfg.deps.concat(mainScript) : [mainScript];
 
                 return true;
+            }
+
+            //Look for a data-baseurl attribute to set the baseUrl.
+            //Used only in optimized mode where require.js is included in output.
+            //Will override data-main reference to baseUrl.
+            //Useful when require.js is included in base module and
+            //the application intend to do dynamic loading of scripts.
+            dataBaseUrl = script.getAttribute('data-baseurl');
+            if(dataBaseUrl) {
+                cfg.baseUrl = dataBaseUrl;
             }
         });
     }


### PR DESCRIPTION
Look for a data-baseurl attribute to set the baseUrl. Will override
data-main reference to baseUrl. Useful when require.js is included into
application startpoint and the application intend to do dynamic loading
of scripts.

This allows for a smooth way to handle the baseUrl based on different environments.

Example with require.js bundled in application.js
`<script src="//domain.s3.amazonaws.com/scripts/application.js" data-baseurl="//domain.s3.amazonaws.com/scripts/"></script>`
