### PR TITLE
Removing word duplication in the introduction of the API page.

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -54,7 +54,7 @@
 <span class="sectionMark">&sect; 1.1</span>
 </h3>
 
-<p>RequireJS takes a different approach to script loading than traditional &lt;script&gt; tags. Its goal is to encourage modular code. While it can also run fast and optimize well, the primary goal is to encourage modular code. As part of that, it encourages using <strong>module IDs</strong> instead of URLs for script tags.</p>
+<p>RequireJS takes a different approach to script loading than traditional &lt;script&gt; tags.  While it can also run fast and optimize well, the primary goal is to encourage modular code. As part of that, it encourages using <strong>module IDs</strong> instead of URLs for script tags.</p>
 
 <p>RequireJS loads all code relative to a <a href="#config-baseUrl">baseUrl</a>. The baseUrl is normally set to the same directory as the script used in a data-main attribute for the top level script to load for a page. The <a href="#data-main">data-main attribute</a> is a special attribute that require.js will check to start script loading. This example will end up with a baseUrl of <strong>scripts</strong>:</p>
 


### PR DESCRIPTION
Il looks to me this sentence is superfluous.
Cheers.
