### PR TITLE
fix directory structure in api.html#packages

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -853,6 +853,8 @@ some modules to load asynchronously as part of a config block.</p>
 <li>project-directory/
 <ul>
 <li>project.html</li>
+<li>scripts/
+<ul>
 <li>cart/
 <ul>
 <li>main.js</li>


### PR DESCRIPTION
`<script data-main="scripts/main" src="scripts/require.js"></script>`

means directory structure should be:
- project-directory/
  - project.html
  - scripts/ # ADDED, nest under /scripts
    - cart/
      - main.js
    - store/
      - main.js
      - util.js
    - main.js
    - require.js

Instead of:
- project-directory/
  - project.html
  - cart/
    - main.js
  - store/
    - main.js
    - util.js
  - main.js
  - require.js
