### PR TITLE
trimDots copes with an empty path segment

### DIFF
--- a/require.js
+++ b/require.js
@@ -228,7 +228,7 @@ var requirejs, require, define;
          */
         function trimDots(ary) {
             var i, part;
-            for (i = 0; ary[i]; i += 1) {
+            for (i = 0, l = ary.length; i < l; i += 1) {
                 part = ary[i];
                 if (part === '.') {
                     ary.splice(i, 1);


### PR DESCRIPTION
Having baseUrl: '/base' and referencing '../dep' path from 'mod1' module and from another module 'mod2' using the the same '../dep' the 'dep' module actually loads twice.

Reason:
'/base/mod1/../dep'.split(/) ~ ['', 'base', 'mod1', '..', 'dep']
'/base/mod2/../dep'.split(/) ~ ['', 'base', 'mod2', '..', 'dep']

The trimDots() in its original version stopped on the first empty string path segment and let the resulting normalized module IDs differ.
