### PR TITLE
generate bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "requirejs",
+  "version": "2.1.9",
+  "homepage": "http://requirejs.org",
+  "authors": [
+    "jrburke.com"
+  ],
+  "description": "A file and module loader for JavaScript",
+  "main": "require.js",
+  "keywords": [
+    "AMD"
+  ],
+  "license": "new BSD, and MIT",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
Mentioned in issues: https://github.com/jrburke/requirejs/issues/975
Content of the file:

``` json
{
  "name": "requirejs",
  "version": "2.1.9",
  "homepage": "http://requirejs.org",
  "authors": [
    "jrburke.com"
  ],
  "description": "A file and module loader for JavaScript",
  "main": "require.js",
  "keywords": [
    "AMD"
  ],
  "license": "new BSD, and MIT",
  "ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "test",
    "tests"
  ]
}
```
