### PR TITLE
Cache Busting: Inject a configurable string into JS filenames

### DIFF
--- a/require.js
+++ b/require.js
@@ -1576,7 +1576,7 @@ var requirejs, require, define;
              * internal API, not a public one. Use toUrl for the public API.
              */
             nameToUrl: function (moduleName, ext, skipExt) {
-                var paths, syms, i, parentModule, url,
+                var paths, syms, i, parentModule, url, jsExt,
                     parentPath, bundleId,
                     pkgMain = getOwn(config.pkgs, moduleName);
 
@@ -1622,9 +1622,13 @@ var requirejs, require, define;
                         }
                     }
 
+
                     //Join the path parts together, then figure out if baseUrl is needed.
                     url = syms.join('/');
-                    url += (ext || (/^data\:|\?/.test(url) || skipExt ? '' : '.js'));
+
+                    jsExt = ((!url.match(/^[\w\+\.\-]+:/) && config.cacheSuffix) ? config.cacheSuffix : '') + '.js';
+
+                    url += (ext || (/^data\:|\?/.test(url) || skipExt ? '' : jsExt));
                     url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
                 }
 


### PR DESCRIPTION
A lot of users ask on StackOverflow how to do cache busting with requirejs. The typical answer is to use urlArgs, but that solution has problems. Unfortunately you cannot control all proxy servers that might be between you and your user's web browser. Some of these proxy servers can be unfortunately configured to ignore URL parameters when caching files. If this happens, the wrong version of your JS file will be delivered to your user.

This pull request adds a config parameter `cacheSuffix`, which you can use like this:

```
var require = {
    baseUrl: "/scripts/",
    cacheSuffix: ".buildNumber"
}
```

Use your build system or server environment to replace `buildNumber` with a revision id / software version / favorite color.

Using require like this:

```
require(["myModule"], function() {
    // no-op;
});
```

Will cause require to request this file:

```
http://yourserver.com/scripts/myModule.buildNumber.js
```

On our server environment, we use url rewrite rules to strip out the buildNumber, and serve the correct JS file. This way we don't actually have to worry about renaming all of our JS files.

The patch will ignore any script that specifies a protocol, and it will not affect any non-JS files.

This works well for us in our environment, but I realize some users would prefer a prefix rather than a suffix, so I would understand if you did not want to incorporate this exact patch into require. I hope you will consider something like this solution however.

I did consider implementing this using a callback method that could be provided in config, like a 'rewriteUrl()' function, but decided the complexity of a function like that would be too high for the average developer to wrestle with.

Here are some of the questions on SO for reference:

http://stackoverflow.com/questions/18242756/requirejs-and-proxy-caching/21619297#21619297

http://stackoverflow.com/questions/13833094/require-js-how-can-i-set-a-version-on-required-modules-as-part-of-the-url/21619238#21619238
