### PR TITLE
Added optional extended context feature

### DIFF
--- a/require.js
+++ b/require.js
@@ -822,6 +822,60 @@ var requirejs, require, define;
             },
 
             /**
+             * Create a extended context to be exported to the require callback.
+             * Need to be enabled in the configs using `extContext: true`.
+             * 
+             * It will prototype the window element, so it's retro-compatible
+             */
+            createExtContext: function (exports, depMaps, depExports) {
+                if (!config.extContext || exports || !depMaps) {
+                    return exports;
+                }
+
+                function ExtContext(){}
+                ExtContext.prototype = (function () { return this;})();
+
+                function resolvePath(map, path, exp, symbol) {
+                    if (!symbol) {
+                        resolvePath(map, path, exp, '/');
+                        symbol = '.';
+                    }
+                    path = path.replace(/\.\./g, 'parentDir');
+
+                    if (path.indexOf(symbol).length < 0) {
+                        return map[path] = exp;
+                    }
+
+                    var p = path.split(symbol);
+
+                    var level = map;
+                    for (var i = 0; i < p.length; i++) {
+                        if (!level[p[i]]) {
+                            level[p[i]] = {};
+                        }
+                        if (p.length - 1 === i) {
+                            level[p[i]] = exp;
+                        }
+                        level = level[p[i]];
+                    }
+                    return map;
+                }
+
+                var map = new ExtContext();
+                for (var i = 0; i < depMaps.length; i++) {
+                    if (depMaps[i].name !== depMaps[i].originalName) {
+                        resolvePath(map, depMaps[i].originalName, depExports[i]);
+                    }
+                    if (depMaps[i].name === depMaps[i].id) {
+                        resolvePath(map, depMaps[i].name, depExports[i]);
+                        continue;
+                    }
+                    resolvePath(map, depMaps[i].id, depExports[i]);
+                }
+                return map;
+            },
+
+            /**
              * Checks if the module is ready to define itself, and if so,
              * define it.
              */
@@ -833,7 +887,7 @@ var requirejs, require, define;
                 var err, cjsModule,
                     id = this.map.id,
                     depExports = this.depExports,
-                    exports = this.exports,
+                    exports = this.createExtContext(this.exports, this.depMaps, depExports),
                     factory = this.factory;
 
                 if (!this.inited) {


### PR DESCRIPTION
Extended Context is a feature, that when using the `Define`or `Require` with AMD (not compatibility mode) it apply in the callback function the context that contains re-maped objects with dependence exports and it prototype the `root` element (root on the nodejs or window in browsers).

Need to add a config `extContext: true` to enable this feature, so it doesn't change for the current projects.

When enabled, it still retro-compatible.

Usage example:

```
define(['moduleA', 'submodule/moduleB', '../parentModuleC'], function () {
    console.log(this); // return the extContext with root as it prototype

    this.moduleA; // return moduleA export
    this.submodule.moduleB; // return submodule/moduleB export
    this.parentDir.parentModuleC // return ../parentModuleC export
});
```

When we are using requirejs in huge projects, it's commun to import a big list of dependences for a module, to maintain the argument list in order is a challange. This way the order doesn't matter. And is very easy to debbug the modules export available in the context.
