### PR TITLE
Modified requirejs: remote urls wouldn't have version query param

### DIFF
--- a/require.js
+++ b/require.js
@@ -1624,13 +1624,16 @@ var requirejs, require, define;
 
                     //Join the path parts together, then figure out if baseUrl is needed.
                     url = syms.join('/');
+                    if(parentPath) {
+                        skipExt = true;
+                    }
                     url += (ext || (/^data\:|\?/.test(url) || skipExt ? '' : '.js'));
                     url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
                 }
 
-                return config.urlArgs ? url +
-                                        ((url.indexOf('?') === -1 ? '?' : '&') +
-                                         config.urlArgs) : url;
+                return config.urlArgs ? (parentPath ? url : (url +
+                    ((url.indexOf('?') === -1 ? '?' : '&') +
+                        config.urlArgs))) : url;
             },
 
             //Delegates to req.load. Broken out as a separate function to


### PR DESCRIPTION
If requirejs uses remote scripts which are hosted for example on google, like jquery, angularjs etc.
In this case if query param added in requirejs config (for example //ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js?v=0.0.1) - google hosting would show error.
This fix doing next:
It doesn't append query params to url if this url is remote.
