### PR TITLE
Add space after ',' (minor)

### DIFF
--- a/tests/commonjs/tests/modules/1.0/missing/program.js
+++ b/tests/commonjs/tests/modules/1.0/missing/program.js
@@ -1,4 +1,4 @@
-define(["require", "exports", "module", "test","bogus"], function(require, exports, module) {
+define(["require", "exports", "module", "test", "bogus"], function(require, exports, module) {
 var test = require('test');
 try {
     require('bogus');


### PR DESCRIPTION
I hate when syntax is inconsistent... Yes, i'm perfectionist.

**Post Scriptum:** There are still problems with the function-keyword: sometimes there are a space after `function` and sometimes not.
