### PR TITLE
Fixed trimDots() for paths that contain ".." in the middle

### DIFF
--- a/require.js
+++ b/require.js
@@ -239,15 +239,7 @@ var requirejs, require, define;
                     ary.splice(i, 1);
                     i -= 1;
                 } else if (part === '..') {
-                    if (i === 1 && (ary[2] === '..' || ary[0] === '..')) {
-                        //End of the line. Keep at least one non-dot
-                        //path segment at the front so it can be mapped
-                        //correctly to disk. Otherwise, there is likely
-                        //no path mapping for a path starting with '..'.
-                        //This can still fail, but catches the most reasonable
-                        //uses of ..
-                        break;
-                    } else if (i > 0) {
+                    if (i > 0 && ary[i-1] !== ".." && ary[i-1] !== ".") {
                         ary.splice(i - 1, 2);
                         i -= 2;
                     }


### PR DESCRIPTION
trimDot() does not remove ".." in the middle of the path array:

pathSegments = ["a", "b", "..", "d"];
trimDot(pathSegments);

Expected:
["a", "d"]
Actual:
["a", "b", "..", "d"]

This commit fixes this problem.

This issue occures in AMD-modules generated with the TypeScript compiler when referencing other modules by relative paths.
