### PR TITLE
"delay" handler for definitions with async calls

### DIFF
--- a/require.js
+++ b/require.js
@@ -1,5 +1,5 @@
 /** vim: et:ts=4:sw=4:sts=4
- * @license RequireJS 2.1.11 Copyright (c) 2010-2014, The Dojo Foundation All Rights Reserved.
+ * @license RequireJS 2.1.11+ Copyright (c) 2010-2014, The Dojo Foundation All Rights Reserved.
  * Available via the MIT or new BSD license.
  * see: http://github.com/jrburke/requirejs for details
  */
@@ -12,7 +12,7 @@ var requirejs, require, define;
 (function (global) {
     var req, s, head, baseElement, dataMain, src,
         interactiveScript, currentlyAddingScript, mainScript, subPath,
-        version = '2.1.11',
+        version = '2.1.11+',
         commentRegExp = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg,
         cjsRequireRegExp = /[^.]\s*require\s*\(\s*["']([^'"\s]+)["']\s*\)/g,
         jsSuffixRegExp = /\.js$/,
@@ -180,7 +180,7 @@ var requirejs, require, define;
 
     if (typeof requirejs !== 'undefined') {
         if (isFunction(requirejs)) {
-            //Do not overwrite and existing requirejs instance.
+            //Do not overwrite an existing requirejs instance.
             return;
         }
         cfg = requirejs;
@@ -379,7 +379,13 @@ var requirejs, require, define;
                 //retry
                 pathConfig.shift();
                 context.require.undef(id);
-                context.require([id]);
+
+                //Custom require that does not do map translation, since
+                //ID is "absolute", already mapped/resolved.
+                context.makeRequire(null, {
+                    skipMap: true
+                })([id]);
+
                 return true;
             }
         }


### PR DESCRIPTION
Some modules do need to perform asynchronous calls to be fully initialized.
In example :
IndexDB calls https://developer.mozilla.org/en/docs/IndexedDB
Ajax requests
Blob builders
Custom methods with asynchronous tasks

To get sure that the asynchronous calls are performed before the defined events are triggered, it is possible to use a plugin that will manually handle those special cases. The problem is that to delay the "define" event, the plugin has to used for each require which creates redundancy across secondary modules depending on the first module requiring async calls. It would be more logical if the async nature of a module was in its definition.
The idea would be to not only load modules asynchronously but also to get their value asynchronously.
The best idea I found was to create a new special handler ( like "require", "exports" or "module" ) called "delay" and being a callback function for the return value.
For example it would look this way :

   define(["delay"], function ( delay ) { // depends on the "delay" handler : the value will be returned asynchronously
        var Module = ... ;
        setTimeout(function(){ //Some asynchronous actions
            delay(Module) ; //This does actually returns the Module's value and triggers the "defined" event.
                            //It's transparent, just as if the loading time over the network was a bit longer.
        },1000);
        return Module ; //This does not do anything because delay is active
    });

This was achieved with only a few lines of code (check the diff) and could offer a useful feature to get a better structured module when its initialization does not simple rely on the load of the file.

PS : I do have a CLA with Dojo
