### PR TITLE
Unnecessary iterations in trimDot

### DIFF
--- a/require.js
+++ b/require.js
@@ -232,8 +232,8 @@ var requirejs, require, define;
          * @param {Array} ary the array of path segments.
          */
         function trimDots(ary) {
-            var i, part, length = ary.length;
-            for (i = 0; i < length; i++) {
+            var i, part;
+            for (i = 0; i < ary.length; i++) {
                 part = ary[i];
                 if (part === '.') {
                     ary.splice(i, 1);


### PR DESCRIPTION
Due to the array being changed during the loop, storing the length at the beginning is leading to unnecessary iteration if a ".." or a "." is found in the name. This may also be harmful in the future as this is probably not wanted.
