### PR TITLE
Fix issue #1107 - normalized relative paths

### DIFF
--- a/require.js
+++ b/require.js
@@ -366,7 +366,7 @@ var requirejs, require, define;
             //  "path/../" with ""
             //  "/./" with "/"
             //  "./" with ""
-            path.replace(/(^|\/)\.\//,'$1');
+            path = path.replace(/(^|\/)\.\//,'$1');
             while( regParent.test(path) ){
                 path = path.replace( regParent, '$1');
             }


### PR DESCRIPTION
This removes possible duplicating errors from same assets having different paths, e.g.

This finds and replaces strings withing the path name
"/path/../" with "/"
"path/../" with ""
"/./" with "/"
"./" with ""

E.g.

```
lib/../../bower_components/hello/src/modules/../hello
```

becomes

```
../bower_components/hello/src/hello
```

As described by #1107 
