### PR TITLE
use a more precise way to check moduleName

### DIFF
--- a/require.js
+++ b/require.js
@@ -1598,7 +1598,7 @@ var requirejs, require, define;
                     return context.nameToUrl(bundleId, ext, skipExt);
                 }
 
-                //If a colon is in the URL, it indicates a protocol is used and it is just
+                //If a :// is in the URL, it indicates a protocol is used and it is just
                 //an URL to a file, or if it starts with a slash, contains a query arg (i.e. ?)
                 //or ends with .js, then assume the user meant to use an url and not a module id.
                 //The slash is important for protocol-less URLs as well as full paths.
@@ -1773,7 +1773,7 @@ var requirejs, require, define;
     req.version = version;
 
     //Used to filter out dependencies that are already paths.
-    req.jsExtRegExp = /^\/|:|\?|\.js$/;
+    req.jsExtRegExp = /^\/|:\/\/|\?|\.js$/;
     req.isBrowser = isBrowser;
     s = req.s = {
         contexts: contexts,


### PR DESCRIPTION
We want use moduleName with colon in it to specify the namespace of the module, for example

``` javscript
require(['common:jquery', 'home:index' ,function($, index){

});
```

and we want to use paths to locate the module

``` javascipt
require.config({
    paths: {
        "common:jquery" : path/to/jquery,
        "home:index" : path/to/index
    }
});
```

but the `common:jquery` was recognized as a url path, so I think we need a more precise way to check the url pattern.
