### PR TITLE
API doc: add missing list item to example

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -97,6 +97,7 @@ up locations of a group of scripts. All of these capabilities allow you to use s
                 <li>canvas.js</li>
             </ul></li>
             <li>app.js</li>
+            <li>require.js</li>
         </ul></li>
     </ul></li>
 </ul>


### PR DESCRIPTION
This is missing, right?
