### PR TITLE
Adding a config option to stop assuming module filenames end in .js

### DIFF
--- a/require.js
+++ b/require.js
@@ -1644,6 +1644,10 @@ var requirejs, require, define;
             //Delegates to req.load. Broken out as a separate function to
             //allow overriding in the optimizer.
             load: function (id, url) {
+                if (config.disableAutoJsExt && url.match(/\..*\.js$/)) {
+                    url = url.replace(/\.js$/, '');
+                }
+
                 req.load(context, id, url);
             },
 


### PR DESCRIPTION
Adds a config option to stop assuming module filenames end in .js

When disableAutoJsExt: true, is set you have to pass complete file
names including extension when requiring modules such as foo.js or
foo.njs instead of foo

I am using require.js server side with node.js and I need to name my
modules .njs or .model etc to separate them from static .js files.

The noext plugin does not work serverside with node.js and I feel
assuming a file ext is unwise in general. If I missed an obvious way
to accomplish this, please let me know. Someone more familiar with
requirejs code then me should review and modify this patch as needed.
Making sure it doesn't break anything (like undef etc).

However it is done I think allowing non .js file extensions for
module files is important.
