### PR TITLE
Add onBeforeNodeInserted hook

### DIFF
--- a/require.js
+++ b/require.js
@@ -1941,6 +1941,10 @@ var requirejs, require, define;
             }
             node.src = url;
 
+            if (config.onBeforeNodeInserted) {
+                config.onBeforeNodeInserted(node, config, moduleName, url);
+            }
+
             //For some cache cases in IE 6-8, the script executes before the end
             //of the appendChild execution, so to tie an anonymous define
             //call to the module name (which is stored on the node), hold on

--- a/tests/all.js
+++ b/tests/all.js
@@ -205,3 +205,5 @@ doh.registerUrl("errorChild", "../error/errorChild.html");
 doh.registerUrl("pathArray", "../pathArray/pathArray.html", 8000);
 doh.registerUrl("pathArrayWithMap", "../pathArray/withMap/withMap.html", 8000);
 doh.registerUrl("pathArrayFail", "../pathArray/pathArrayFail.html", 10000);
+
+doh.registerUrl("onBeforeNodeInserted", "../onBeforeNodeInserted.html");

--- a/tests/onBeforeNodeInserted.html
+++ b/tests/onBeforeNodeInserted.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: Empty Dependency Test</title>
+    <script type="text/javascript" src="doh/runner.js"></script>
+    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script type="text/javascript">
+        var gotHere = false;
+        var pathUrl = '//code.jquery.com/jquery-2.2.0.min.js';
+        var depURL = '';
+
+        var require = {
+            urlArgs: 'v=1',
+            paths: {
+                jquery: pathUrl.replace('.js', '')
+            },
+            onBeforeNodeInserted: function(node, config, moduleName, url) {
+                gotHere = true;
+                depURL = url.replace('?' + config.urlArgs, '');
+            }
+        };
+    </script>
+    <script type="text/javascript" src="../require.js"></script>
+    <script type="text/javascript">
+        require(['jquery'], function ($) {
+            doh.register(
+                'onBeforeNodeInserted',
+                [
+                    function onBeforeNodeInserted(t) {
+                        t.is(true, gotHere, 'event triggered');
+                        t.is(pathUrl, depURL, 'urlArgs removed');
+                    }
+                ]
+            );
+            doh.run();
+        });
+    </script>
+</head>
+<body>
+    <h1>require.js: onBeforeNodeInserted Test</h1>
+    <p>If <code>onBeforeNodeInserted</code> is specified, fire it before inserting the node into the DOM.</p>
+    <p>Check console for messages</p>
+</body>
+</html>


### PR DESCRIPTION
Adds a `onBeforeNodeInserted` event that – if configured – fires immediately before adding the nodes to the DOM. It's very similar to the `onNodeCreated` that already exists, but fires after all other attributes have been added to the node.

This event can be used to resolve the issues raised by #376.