### PR TITLE
fix typo for consistency

### DIFF
--- a/docs/why.html
+++ b/docs/why.html
@@ -58,8 +58,8 @@ used by RequireJS.</p>
 
 <ul>
 <li>Some sort of #include/import/require</li>
-<li>ability to load nested dependencies</li>
-<li>ease of use for developer but then backed by an optimization tool that helps deployment</li>
+<li>Ability to load nested dependencies</li>
+<li>Ease of use for developer but then backed by an optimization tool that helps deployment</li>
 </ul>
 </div>
 


### PR DESCRIPTION
capitalized first word in `solution` section on `why web modules` page - trivial, yet necessary :+1: 