### PR TITLE
Avoid issues caused by clobbering of global setTimeout

### DIFF
--- a/require.js
+++ b/require.js
@@ -8,7 +8,7 @@
 /*global window, navigator, document, importScripts, setTimeout, opera */
 
 var requirejs, require, define;
-(function (global) {
+(function (global, setTimeout) {
     var req, s, head, baseElement, dataMain, src,
         interactiveScript, currentlyAddingScript, mainScript, subPath,
         version = '2.2.0',
@@ -2139,4 +2139,4 @@ var requirejs, require, define;
 
     //Set up with config info.
     req(cfg);
-}(this));
+}(this, setTimeout));

--- a/tests/all.js
+++ b/tests/all.js
@@ -7,6 +7,8 @@ var hasToString = (function () {
 
 doh.registerUrl("simple", "../simple.html");
 
+doh.registerUrl("setTimeout", "../setTimeout.html");
+
 //PS3 does not like this test
 doh.registerUrl("baseUrl", "../baseUrl.html");
 

--- a/tests/setTimeout-tests.js
+++ b/tests/setTimeout-tests.js
@@ -1,0 +1,25 @@
+(function (global) {
+    // Store local setTimeout reference for monkey-patching DOH
+    var localSetTimeout = global.setTimeout;
+
+    // Clobber setTimeout to ensure that the below require() still works...
+    global.setTimeout = null;
+
+    // ...but ensure doh.setTimeout does not get broken
+    doh.setTimeout = function (fn, delay) {
+    	return localSetTimeout.call(global, fn, delay);
+    };
+
+    require({ baseUrl: "./" }, ["simple"], function(simple) {
+        doh.register(
+            "setTimeout",
+            [
+                function checkSetTimeout(t){
+                    t.is("blue", simple.color);
+                }
+            ]
+        );
+
+        doh.run();
+    });
+})(this);

--- a/tests/setTimeout.html
+++ b/tests/setTimeout.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>require.js: setTimeout Test</title>
+    <script type="text/javascript" src="../require.js"></script>
+    <script type="text/javascript" src="doh/runner.js"></script>
+    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script type="text/javascript" src="setTimeout-tests.js"></script>
+</head>
+<body>
+    <h1>require.js: setTimeout Test</h1>
+    <p>Check console for messages</p>
+</body>
+</html>


### PR DESCRIPTION
Improved version of PR #1402. Uses unqualified `setTimeout` as closure argument to avoid this vs global vs window issues.

The rest of this description is lifted from original PR.

Ensuring global setTimeout reference is captured in require.js so that clobbering setTimeout does not break everything.

This is useful/necessary when using RequireJS with a unit test framework that simulates setTimeout (for example sinon.js). Since RequireJS relies on the default behavior of setTimeout and is a library which ideally should function the same way even when other frameworks are involved, it seems worthwhile to close over the default setTimeout function.

I've also added a unit test file to capture this-- please let me know if that can be improved.