### PR TITLE
Allow plugin suffix rather than prefix, defaulting to file extension

### DIFF
--- a/require.js
+++ b/require.js
@@ -391,7 +391,7 @@ var requirejs, require, define;
         function splitPrefix(name) {
             var prefix,
                 index = name ? name.indexOf('!') : -1;
-            if (config.plugin == 'suffix'){
+            if (getOwn(config, 'plugin') == 'suffix'){
                 if (index > -1) {
                     name = name.substring(0, index);
                     prefix = name.substring(index + 1, name.length);

--- a/require.js
+++ b/require.js
@@ -395,9 +395,9 @@ var requirejs, require, define;
                 if (index > -1) {
                     name = name.substring(0, index);
                     prefix = name.substring(index + 1, name.length);
-                    if (prefix.length == 0){
+                    if (prefix.length == 0) {
                         index = name ? name.lastIndexOf('.') : -1;
-                        if (index > -1){
+                        if (index > -1) {
                             prefix = name.substring(index + 1, name.length);
                         }
                     }

--- a/require.js
+++ b/require.js
@@ -391,7 +391,7 @@ var requirejs, require, define;
         function splitPrefix(name) {
             var prefix,
                 index = name ? name.indexOf('!') : -1;
-            if (getOwn(config, 'plugin') == 'suffix'){
+            if (getOwn(config, 'plugin') == 'suffix') {
                 if (index > -1) {
                     name = name.substring(0, index);
                     prefix = name.substring(index + 1, name.length);

--- a/require.js
+++ b/require.js
@@ -390,20 +390,19 @@ var requirejs, require, define;
         //did not have a plugin prefix.
         function splitPrefix(name) {
             var prefix,
-                index = name ? name.indexOf('!') : -1;
-            if (getOwn(config, 'plugin') == 'suffix') {
-                if (index > -1) {
-                    name = name.substring(0, index);
-                    prefix = name.substring(index + 1, name.length);
-                    if (prefix.length === 0) {
-                        index = name ? name.lastIndexOf('.') : -1;
-                        if (index > -1) {
-                            prefix = name.substring(index + 1, name.length);
-                        }
+                index = name ? name.indexOf('|') : -1;
+            if (index > -1) {
+                name = name.substring(0, index);
+                prefix = name.substring(index + 1, name.length);
+                if (prefix.length === 0) {
+                    index = name ? name.lastIndexOf('.') : -1;
+                    if (index > -1) {
+                        prefix = name.substring(index + 1, name.length);
                     }
                 }
                 return [prefix, name];
             }
+            index = name ? name.indexOf('!') : -1;
             if (index > -1) {
                 prefix = name.substring(0, index);
                 name = name.substring(index + 1, name.length);

--- a/require.js
+++ b/require.js
@@ -395,7 +395,7 @@ var requirejs, require, define;
                 if (index > -1) {
                     name = name.substring(0, index);
                     prefix = name.substring(index + 1, name.length);
-                    if (prefix.length == 0) {
+                    if (prefix.length === 0) {
                         index = name ? name.lastIndexOf('.') : -1;
                         if (index > -1) {
                             prefix = name.substring(index + 1, name.length);

--- a/require.js
+++ b/require.js
@@ -391,6 +391,19 @@ var requirejs, require, define;
         function splitPrefix(name) {
             var prefix,
                 index = name ? name.indexOf('!') : -1;
+            if (config.plugin == 'suffix'){
+                if (index > -1) {
+                    name = name.substring(0, index);
+                    prefix = name.substring(index + 1, name.length);
+                    if (prefix.length == 0){
+                        index = name ? name.lastIndexOf('.') : -1;
+                        if (index > -1){
+                            prefix = name.substring(index + 1, name.length);
+                        }
+                    }
+                }
+                return [prefix, name];
+            }
             if (index > -1) {
                 prefix = name.substring(0, index);
                 name = name.substring(index + 1, name.length);


### PR DESCRIPTION
This reads plugin names from a suffix rather than a prefix.

For instance,
````
require(['my.html|text'], function(html){ ...})
````

If the plugin name is not specified, it defaults to the extension of the file.

For instance,
````
require(['my.css|']);
````