### PR TITLE
Use originalName instead of id to get the configuration

### DIFF
--- a/require.js
+++ b/require.js
@@ -593,7 +593,7 @@ var requirejs, require, define;
                         id: mod.map.id,
                         uri: mod.map.url,
                         config: function () {
-                            return getOwn(config.config, mod.map.id) || {};
+                            return getOwn(config.config, mod.map.originalName) || {};
                         },
                         exports: mod.exports || (mod.exports = {})
                     });


### PR DESCRIPTION
Hello,

First, thanks a lot for this awesome tool ! 😍 

I know that this change may not be accepted because of the risk of BC breaks but this fix a real need:
Let say that I want to use the same source code but have multiple modules. This is simple to do I just have to use the map option:
```javascript
map: {
  '*': {
    'product-saver': 'base-saver',
    'attribute-saver': 'base-saver',
    'family-saver': 'base-saver',
    'option-saver': 'base-saver'
  }
},
paths: {
    'base-saver': '/js/saver/base-saver.js'
}
```

Ok, everything is working fine: when I ask for 'product-saver' I get a new instance of the base-saver.

But what if I would like to have the same file but different configuration when calling `module.config()` ?
Before my PR you cannot have multiple configuration.

After my PR you can do:
```javascript
map: {
  '*': {
    'product-saver': 'base-saver',
    'attribute-saver': 'base-saver',
    'family-saver': 'base-saver',
    'option-saver': 'base-saver'
  }
},
paths: {
    'base-saver': '/js/saver/base-saver.js'
},
conf: {
    'product-saver': {
        'url': '/product/remove'
    },
    'attribute-saver': {
        'url': '/attribute/remove'
    },
    //etc
}
```

You can now have multiple modules with different configuration and use the same source code