### PR TITLE
Fix: support for using require.js in pure XML

### DIFF
--- a/require.js
+++ b/require.js
@@ -1870,7 +1870,9 @@ var requirejs, require, define;
      * Creates the node for the load command. Only used in browser envs.
      */
     req.createNode = function (config, moduleName, url) {
-        var node = config.xhtml ?
+        // We force config.xhtml if the document has no body (ie, it is
+        // an XML document)
+        var node = (config.xhtml||!document.body) ?
                 document.createElementNS('http://www.w3.org/1999/xhtml', 'html:script') :
                 document.createElement('script');
         node.type = config.scriptType || 'text/javascript';
@@ -1952,6 +1954,9 @@ var requirejs, require, define;
             //call to the module name (which is stored on the node), hold on
             //to a reference to this node, but clear after the DOM insertion.
             currentlyAddingScript = node;
+            // Pure XML documents do not have head, so we instead get the
+            // root's first child.
+            head = head || document.rootNode.firstChild;
             if (baseElement) {
                 head.insertBefore(node, baseElement);
             } else {


### PR DESCRIPTION
`require.js` does not work with pure-XML documents right now. This patch fixes it.

```
<?xml version="1.0" encoding="UTF-8"?>
<Application xmlns:html="http://www.w3.org/1999/xhtml">
	<html:script type="text/javascript" src="http://requirejs.org/docs/release/2.2.0/minified/require.js" />
        <html:script type="text/javascript">require(["underscore"]);</html:script>
</Application>
```

vs

```
<?xml version="1.0" encoding="UTF-8"?>
<Application xmlns:html="http://www.w3.org/1999/xhtml">
	<html:script type="text/javascript" src="https://raw.githubusercontent.com/sebastien/requirejs/master/require.js" />
        <html:script type="text/javascript">require(["underscore"]);</html:script>
</Application>
```

