### PR TITLE
Remove the base tag hack for IE6

### DIFF
--- a/require.js
+++ b/require.js
@@ -1850,13 +1850,6 @@ var requirejs, require, define;
 
     if (isBrowser) {
         head = s.head = document.getElementsByTagName('head')[0];
-        //If BASE tag is in play, using appendChild is a problem for IE6.
-        //When that browser dies, this can be removed. Details in this jQuery bug:
-        //http://dev.jquery.com/ticket/2709
-        baseElement = document.getElementsByTagName('base')[0];
-        if (baseElement) {
-            head = s.head = baseElement.parentNode;
-        }
     }
 
     /**


### PR DESCRIPTION
Microsoft stop support IE6 until 2014.
https://www.sitepoint.com/microsoft-support-ie6-2014/