### PR TITLE
Fix link to LICENSE file

### DIFF
--- a/require.js
+++ b/require.js
@@ -1,6 +1,6 @@
 /** vim: et:ts=4:sw=4:sts=4
  * @license RequireJS 2.2.0 Copyright jQuery Foundation and other contributors.
- * Released under MIT license, http://github.com/requirejs/requirejs/LICENSE
+ * Released under MIT license, https://github.com/requirejs/requirejs/blob/master/LICENSE
  */
 //Not using strict: uneven strict support in browsers, #392, and causes
 //problems with requirejs.exec()/transpiler plugins that may not be strict.


### PR DESCRIPTION
It looks like no-one actually goes to read the license of a library these days = ) This commit updates the link to the LICENSE file, hosted in the requirejs GitHub repository.