### PR TITLE
Update commentRegExp for better sugared CommonJS syntax dependency parsing

### DIFF
--- a/require.js
+++ b/require.js
@@ -12,7 +12,7 @@ var requirejs, require, define;
     var req, s, head, baseElement, dataMain, src,
         interactiveScript, currentlyAddingScript, mainScript, subPath,
         version = '2.2.0',
-        commentRegExp = /(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg,
+        commentRegExp = /\/\*[\s\S]*?\*\/|([^:"'=]|^)\/\/.*$/mg,
         cjsRequireRegExp = /[^.]\s*require\s*\(\s*["']([^'"\s]+)["']\s*\)/g,
         jsSuffixRegExp = /\.js$/,
         currDirRegExp = /^\.\//,
@@ -36,7 +36,7 @@ var requirejs, require, define;
         useInteractive = false;
 
     //Could match something like ')//comment', do not lose the prefix to comment.
-    function commentReplace(match, multi, multiText, singlePrefix) {
+    function commentReplace(match, singlePrefix) {
         return singlePrefix || '';
     }
 

--- a/tests/remoteUrls/jqwrap.js
+++ b/tests/remoteUrls/jqwrap.js
@@ -1,10 +1,29 @@
 define(function (require) {
-    //Tests detecting a full URL dependency inside simplified wrapper.
+    //Test a full URL dependency inside simplified wrapper.
     require('https://ajax.googleapis.com/ajax/libs/jquery/1.6.4/jquery.min.js');
+
+    //Test protocol relative URL.
+	require('//ajax.googleapis.com/ajax/libs/swfobject/2.2/swfobject.js');
+
+    var s = '<img src="//www.example.com/loading.gif"/>'; var util = require('util');
+
+    var t = '<img src=//www.example.com/loading.gif/>'; var util2 = require('util2');
+
+    //Make sure that this does not match, a string with no semicolon
+    //after it, but with a line break before a commented out require.
+    var something = 'something'
+//require('bad');
+
+	//--------
+    //This will match if this comment removed to here: var something = 'something'// require('bad');
+	//--------
 
     function noop() {};
 
     return {
-        isFunction: jQuery.isFunction(noop)
+        isFunction: jQuery.isFunction(noop),
+        swfobject: swfobject,
+        util: util,
+        util2: util2
     };
 });

--- a/tests/remoteUrls/remoteUrls-tests.js
+++ b/tests/remoteUrls/remoteUrls-tests.js
@@ -8,6 +8,9 @@ require({
             [
                 function remoteUrls(t){
                     t.is(true, jqwrap.isFunction);
+                    t.is(true, !!jqwrap.swfobject);
+                    t.is('util', jqwrap.util.name);
+                    t.is('util2', jqwrap.util2.name);
                 }
             ]
         );

--- a/tests/remoteUrls/util.js
+++ b/tests/remoteUrls/util.js
@@ -1,0 +1,3 @@
+define({
+	name: 'util'
+});

--- a/tests/remoteUrls/util2.js
+++ b/tests/remoteUrls/util2.js
@@ -1,0 +1,3 @@
+define({
+	name: 'util2'
+});


### PR DESCRIPTION
This is a combo fix for the issues described here:

* #1538
* #1539
* #1546

It uses some of the same techniques described in those tickets, but combined and with tests and passing code validation requirements. The main changes to the regexp:

* Remove () matching groups that were not used in processing the match, to make it faster: ~500,000 ops/sec vs the old one at ~410,000 ops/sec, using the benchmark mentioned in #1538 when run in node 6.2.1 on my personal laptop. The `commentReplace` function was updated to remove parameters that corresponded to the match groups removed.
* Include `'"=` in the "do not match if starts with those characters" part of the regexp. This allows matching better for protocol relative URLs, and for having an HTML attribute preceding the require('') call on the same line.

This does mean though that it will now falsely match on this sort of construct:

```javascript
var something = 'something'// require('bad');
```

However, this sort of regexp based approach will always have edge cases, and for the case above, it seems unlikely to happen in the wild:

* There would likely be a line return if the "don't use trailing semicolons" style is used. If this above case is hit, the workaround is just to place a line return after the string.
* This form is more likely to show up in a file that has been minified, but in that case the comment should have been stripped.

So the benefits on catching more true positives seem worth this tradeoff.

Note that this regexp is only used for dynamic loading when there is no dependency array passed in the define call. If the r.js optimizer is used, it finds dependencies via an AST so it would not have any false positives or negatives associated with this regexp, and is always an option if a workaround is needed. The r.js optimizer also writes out a dependency array in the define calls, so it avoids this regexp work at runtime when an optimized build is used.

However, since this is a long-standing regexp in the system, I will rev the release version with this change to 2.3.0 to indicate a feature change. alameda will also be updated to match.