### PR TITLE
Improve comment removal; fixes #1593

### DIFF
--- a/require.js
+++ b/require.js
@@ -12,7 +12,7 @@ var requirejs, require, define;
     var req, s, head, baseElement, dataMain, src,
         interactiveScript, currentlyAddingScript, mainScript, subPath,
         version = '2.3.2',
-        commentRegExp = /\/\*[\s\S]*?\*\/|([^:"'=]|^)\/\/.*$/mg,
+        commentRegExp = /('(?:[^']|\\')*'|"(?:[^"]|\\")*"|\/(?:[^\/]|\\\/)+\/)|\/[*][\s\S]*?[*]\/|\/\/.*$/mg,
         cjsRequireRegExp = /[^.]\s*require\s*\(\s*["']([^'"\s]+)["']\s*\)/g,
         jsSuffixRegExp = /\.js$/,
         currDirRegExp = /^\.\//,
@@ -35,9 +35,14 @@ var requirejs, require, define;
         globalDefQueue = [],
         useInteractive = false;
 
-    //Could match something like ')//comment', do not lose the prefix to comment.
-    function commentReplace(match, singlePrefix) {
-        return singlePrefix || '';
+    // Keep strings and regexp literals, convert /**/ comments to space in case there's no space on either side of them;
+    // simpler alternative if `some/* comments */thing`->`something` instead of `some thing` does not matter: commentReplace = '$1'
+    function commentReplace(match, keep) {
+        if (/^\/[*][\s\S]*?[*]\/$/.test(match)) {
+            return ' ';
+        } else {
+            return keep || '';
+        }
     }
 
     function isFunction(it) {


### PR DESCRIPTION
I think this covers every possible edge case:
- ignores comments inside `'strings'`, `"strings"` and `/regex literals/` (e.g. `/\/*/`) via basically the same alternation technique as used to ignore comments of one type within another (and, by extension, regexes inside strings, strings inside regexes or strings of one quote type inside another are also not an issue)
- shouldn't trip up over escaped quotes in strings (or escaped `/` in regex literals)
- shouldn't mistake `//` for an empty regex literal
- should still keep everything other than comments
- turns `/**/` into a space just in case it's the only thing separating two things that would change in meaning if no longer separated (I'm not sure if this is strictly necessary; if it's not, `commentReplace` can be changed to just the string `'$1'`)