### PR TITLE
Fixed a problem while loading the same shim module by url and config name

### DIFF
--- a/require.js
+++ b/require.js
@@ -221,6 +221,7 @@ var requirejs, require, define;
             defined = {},
             urlFetched = {},
             bundlesMap = {},
+            initedModules = {},
             requireCounter = 1,
             unnormalizedCounter = 1;
 
@@ -773,6 +774,8 @@ var requirejs, require, define;
 
                 //Indicate this module has be initialized
                 this.inited = true;
+                //Store reference for module aliases
+                initedModules[this.map.id] = true;
 
                 this.ignore = options.ignore;
 
@@ -825,11 +828,19 @@ var requirejs, require, define;
 
             load: function () {
                 var url = this.map.url;
-
+                
                 //Regular dependency.
                 if (!urlFetched[url]) {
-                    urlFetched[url] = true;
+                    urlFetched[url] = this.map.id;
                     context.load(this.map.id, url);
+                }
+                //If module was already loaded by another name.
+                else if (initedModules[urlFetched[url]] && context.defined.hasOwnProperty(urlFetched[url])) {
+                    this.inited = true;
+                    initedModules[this.map.id] = true;
+                    cleanRegistry(this.map.id);
+                    this.defined = true;
+                    this.check();
                 }
             },
 
@@ -1265,6 +1276,7 @@ var requirejs, require, define;
             registry: registry,
             defined: defined,
             urlFetched: urlFetched,
+            initedModules: initedModules,
             defQueue: defQueue,
             defQueueMap: {},
             Module: Module,

--- a/require.js
+++ b/require.js
@@ -828,7 +828,7 @@ var requirejs, require, define;
 
             load: function () {
                 var url = this.map.url;
-                
+
                 //Regular dependency.
                 if (!urlFetched[url]) {
                     urlFetched[url] = this.map.id;


### PR DESCRIPTION
When somewhere in your code there is require(['../path/to/module']) and in some other module define(['module.alias']), and both of them are referring to the same module in shim-mode, only the first one (../path/to/module) will load successfully, any module which depends on 'module.alias' won't load at all, no errors, nothing.

Example:

--- Config
require.config({
paths: {
'module.alias': '../path/to/module'
},
shim: {
'module.alias': {deps: ['some.shim.dep']}
}
});

--- Module 1
define([
'some.shim.dep'
], function () {});

--- Module 2
define([
'module.alias'
], function () {});

--- Inside some module 3
require(['../path/to/module'], function () {})

You won't be able to guess what's the problem because no errors show up in console.