### PR TITLE
Fixes and removed unneded attributes html5

### DIFF
--- a/dist/pre.html
+++ b/dist/pre.html
@@ -11,10 +11,10 @@
     <!--[if IE]> <link rel="stylesheet" type="text/css" href="ie.css" /> <![endif]-->
     <link rel="stylesheet" type="text/css" href="http://ajax.googleapis.com/ajax/libs/dojo/1.4/dojox/highlight/resources/highlight.css">
 
-    <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"></script>
-    <script type="text/javascript" src="init.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.4.4/jquery.min.js"></script>
+    <script src="init.js"></script>
     <script src="http://ajax.googleapis.com/ajax/libs/dojo/1.4/dojo/dojo.xd.js"></script>
-    <script type="text/javascript">
+    <script>
         dojo.require("dojox.highlight");
         dojo.require("dojox.highlight.languages.javascript");
         dojo.require("dojox.highlight.languages.html");

--- a/docs/api.html
+++ b/docs/api.html
@@ -904,7 +904,7 @@ some modules to load asynchronously as part of a config block.</p>
 
 <p>During development it can be useful to use this, however <strong>be sure</strong> to remove it before deploying your code.</p>
 
-<p id="config-scriptType"><strong><a href="#config-scriptType">scriptType</a></strong>: Specify the value for the type="" attribute used for script tags inserted into the document by RequireJS. Default is "text/javascript". To use Firefox's JavaScript 1.8 features, use "text/javascript;version=1.8".</p>
+<p id="config-scriptType"><strong><a href="#config-scriptType">scriptType</a></strong>: Specify the value for the type="" attribute used for script tags inserted into the document by RequireJS. Default is "text/javascript". To use Firefox's JavaScript 1.8 features, use "text/javascript;version=1.8".</br>// in HTML5 we not need to use <b>type</b> attribute, because javascript is default scripting language in HTML5. </p>
 
 <p id="config-skipDataMain"><strong><a href="#config-skipDataMain">skipDataMain</a></strong>: Introduced in RequireJS 2.1.9: If set to <code>true</code>, skips the <a href="#data-main">data-main attribute scanning</a> done to start module loading. Useful if RequireJS is embedded in a utility library that may interact with other RequireJS library on the page, and the embedded version should not do data-main loading.</p>
 

--- a/docs/start.html
+++ b/docs/start.html
@@ -16,7 +16,7 @@
         </li>
     </ul>
 
-    <span class="note">Note: If you are using jQuery, there is a <a href="jquery.md">targeted jQuery tutorial</a></span>
+    <span class="note">Note: If you are using jQuery, there is a <a href="jquery.html">targeted jQuery tutorial</a></span>
 </div>
 
 <div class="section">
@@ -25,7 +25,7 @@
     <span class="sectionMark">&sect; 1</span>
 </h2>
 
-<p>Go to the <a href="download.md">download</a> page and get the file.</p>
+<p>Go to the <a href="download.html">download</a> page and get the file.</p>
 </div>
 
 <div class="section">
@@ -111,7 +111,7 @@ modules.</p>
     <span class="sectionMark">&sect; 3</span>
 </h2>
 
-<p>Once you are finished doing development and want to deploy your code for your end users, you can use the <a href="optimization.md">optimizer</a> to combine the JavaScript files together and minify it. In the example above, it can combine main.js and helper/util.js into one file and minify the result.</p>
+<p>Once you are finished doing development and want to deploy your code for your end users, you can use the <a href="optimization.html">optimizer</a> to combine the JavaScript files together and minify it. In the example above, it can combine main.js and helper/util.js into one file and minify the result.</p>
 </div>
 
 <div class="section">

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
     Opera 10+ ...... compatible &#x2714;
     </p>
 
-    <p><a href="requirejs/tree/master/docs/start.md">Get started</a> then check out the <a href="requirejs/tree/master/docs/api.md">API</a>.</p>
+    <p><a href="docs/start.html">Get started</a> then check out the <a href="docs/api.html">API</a>.</p>
 
     <p>--- */</p>
 </div>

--- a/tests/NAMESPACE.html
+++ b/tests/NAMESPACE.html
@@ -2,10 +2,10 @@
 <html>
 <head>
     <title>require.js: NAMESPACE Test</title>
-    <script type="text/javascript" src="NAMESPACE.js"></script>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript">
+    <script src="NAMESPACE.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script>
         NAMESPACE.require(['one', 'dimple'], function(one, dimple) {
             doh.register(
                         "namespaceTest",

--- a/tests/afterload.html
+++ b/tests/afterload.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: After Load</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript">
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script>
     var d, s, head;
 
     function goRequire() {

--- a/tests/baseUrl.html
+++ b/tests/baseUrl.html
@@ -2,8 +2,8 @@
 <html>
     <head>
         <title>Default baseUrl Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
     <script data-main="../testBaseUrl" src="../require.js"></script>
     </head>
     <body>

--- a/tests/circular.html
+++ b/tests/circular.html
@@ -2,10 +2,10 @@
 <html>
 <head>
     <title>require.js: Circular Test</title>
-    <script type="text/javascript" src="../require.js"></script>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript" src="circular-tests.js"></script>
+    <script src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script src="circular-tests.js"></script>
 </head>
 <body>
     <h1>require.js: Circular Test</h1>

--- a/tests/config.html
+++ b/tests/config.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>require.js: Config Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
     <script>
         function done() {
             doh.register(
@@ -34,7 +34,7 @@
                 }
             };
     </script>
-    <script type="text/javascript" src="../require.js"></script>
+    <script src="../require.js"></script>
 </head>
 <body>
     <h1>require.js: Config Test</h1>

--- a/tests/configRequirejs.html
+++ b/tests/configRequirejs.html
@@ -2,8 +2,8 @@
 <html>
 <head>
     <title>require.js: Config requirejs Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
     <script>
         function require() {
             return "pristine";
@@ -39,7 +39,7 @@
                 }
             };
     </script>
-    <script type="text/javascript" src="../require.js"></script>
+    <script src="../require.js"></script>
 </head>
 <body>
     <h1>require.js: Config requirejs Test</h1>

--- a/tests/depEmpty.html
+++ b/tests/depEmpty.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: Empty Dependency Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript" src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script src="../require.js"></script>
     <script>
     var noneOk = false,
         emptyOk = false;

--- a/tests/depoverlap.html
+++ b/tests/depoverlap.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: Dependency Overlap Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript" data-main="depoverlap" src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script data-main="depoverlap" src="../require.js"></script>
 </head>
 <body>
     <h1>require.js: Dependency Overlap Test</h1>

--- a/tests/multiversion.html
+++ b/tests/multiversion.html
@@ -2,10 +2,10 @@
 <html>
 <head>
     <title>require.js: Multiversion Test</title>
-    <script type="text/javascript" src="../require.js"></script>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript">
+    <script src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script>
 	var doneCount = 0;
 	var master = new doh.Deferred();
 	function done() {

--- a/tests/queryPath.html
+++ b/tests/queryPath.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: Querystring Path Test</title>
-    <script type="text/javascript" src="../require.js"></script>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
     <script>
     require.config({
         paths: {

--- a/tests/setTimeout.html
+++ b/tests/setTimeout.html
@@ -2,10 +2,10 @@
 <html>
 <head>
     <title>require.js: setTimeout Test</title>
-    <script type="text/javascript" src="../require.js"></script>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript" src="setTimeout-tests.js"></script>
+    <script src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script src="setTimeout-tests.js"></script>
 </head>
 <body>
     <h1>require.js: setTimeout Test</h1>

--- a/tests/simple-badbase.html
+++ b/tests/simple-badbase.html
@@ -2,10 +2,10 @@
 <head>
     <title>require.js: Simple Bad Base Test</title>
     <base href="http://some.example.com/path/" />
-    <script type="text/javascript" src="http://127.0.0.1/requirejs/requirejs/require.js"></script>
-    <script type="text/javascript" src="http://127.0.0.1/requirejs/requirejs/tests/doh/runner.js"></script>
-    <script type="text/javascript" src="http://127.0.0.1/requirejs/requirejs/tests/doh/_browserRunner.js"></script>
-    <script type="text/javascript">
+    <script src="http://127.0.0.1/requirejs/requirejs/require.js"></script>
+    <script src="http://127.0.0.1/requirejs/requirejs/tests/doh/runner.js"></script>
+    <script src="http://127.0.0.1/requirejs/requirejs/tests/doh/_browserRunner.js"></script>
+    <script>
         require({
                 baseUrl: "http://127.0.0.1/requirejs/requirejs/tests/"
             },
@@ -25,7 +25,7 @@
             }
         );
     </script>
-    <script type="text/javascript">
+    <script>
         //This test is only in the HTML since it uses an URL for a require
         //argument. It will not work well in say, the Rhino tests.
         var path = location.href.replace(/simple-badbase\.html$/, "foo"),

--- a/tests/simple-nohead.html
+++ b/tests/simple-nohead.html
@@ -3,15 +3,15 @@
 <h1>require.js: Simple Test, no head tag</h1>
 <p>Check console for messages</p>
 
-<script type="text/javascript">
+<script>
 var require = {
     baseUrl: "./"
 };
 </script>
-<script type="text/javascript" src="../require.js"></script>
-<script type="text/javascript" src="doh/runner.js"></script>
-<script type="text/javascript" src="doh/_browserRunner.js"></script>
-<script type="text/javascript">
+<script src="../require.js"></script>
+<script src="doh/runner.js"></script>
+<script src="doh/_browserRunner.js"></script>
+<script>
 require(["require", "simple", "dimple", "func"],
     function(require, simple, dimple, func) {
         doh.register(

--- a/tests/simple.html
+++ b/tests/simple.html
@@ -2,12 +2,12 @@
 <html>
 <head>
     <title>require.js: Simple Test</title>
-    <script type="text/javascript" src="../require.js"></script>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
+    <script src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
     <script>moreSimpleTests = true</script>
-    <script type="text/javascript" src="simple-tests.js"></script>
-    <script type="text/javascript">
+    <script src="simple-tests.js"></script>
+    <script>
         //This test is only in the HTML since it uses an URL for a require
         //argument. It will not work well in say, the Rhino tests.
         var path = location.href.replace(/simple\.html$/, "foo"),

--- a/tests/urlArgsBlob.html
+++ b/tests/urlArgsBlob.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: urlArgsBlob Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript" src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script src="../require.js"></script>
     <script>
 
     var blob = new Blob(["define({name: 'a'});"],

--- a/tests/urlArgsToUrl.html
+++ b/tests/urlArgsToUrl.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: urlArgs + toUrl Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript" src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script src="../require.js"></script>
     <script>
     require.config({
         baseUrl: 'js',

--- a/tests/urlArgsToUrlFunction.html
+++ b/tests/urlArgsToUrlFunction.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: urlArgs Function + toUrl Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript" src="../require.js"></script>
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script src="../require.js"></script>
     <script>
     require.config({
         baseUrl: 'js',

--- a/tests/workers.html
+++ b/tests/workers.html
@@ -2,9 +2,9 @@
 <html>
 <head>
     <title>require.js: Web Workers Test</title>
-    <script type="text/javascript" src="doh/runner.js"></script>
-    <script type="text/javascript" src="doh/_browserRunner.js"></script>
-    <script type="text/javascript">
+    <script src="doh/runner.js"></script>
+    <script src="doh/_browserRunner.js"></script>
+    <script>
         //Start up a web worker and wait for a response from it.
         var worker = new Worker('workers.js'),
             d = new doh.Deferred(),


### PR DESCRIPTION
Fixed some urls - "(...).md [file do not exist] ---> (...).html [file exist]"

removed the "type" attribute from <script> form in .html files, because javascript is default scripting language in HTML5.

Please look at api.html file in documentation directory
---> declaring type="text/javascript:1.8" ... it was good while there was released FireFox in version 4, now we have version 51 !!!