### PR TITLE
Several plugins use same module name. For example:

### DIFF
--- a/require.js
+++ b/require.js
@@ -1197,9 +1197,9 @@ var requirejs, require, define;
             }
         };
 
-        function callGetModule(args) {
+        function callGetModule(args, force) {
             //Skip modules already defined.
-            if (!hasProp(defined, args[0])) {
+            if (force || !hasProp(defined, args[0])) {
                 getModule(makeModuleMap(args[0], null, true)).init(args[1], args[2]);
             }
         }
@@ -1595,8 +1595,10 @@ var requirejs, require, define;
                 //of those calls/init calls changes the registry.
                 mod = getOwn(registry, moduleName);
 
-                if (!found && !hasProp(defined, moduleName) && mod && !mod.inited) {
-                    if (config.enforceDefine && (!shExports || !getGlobal(shExports))) {
+                if (!found) {
+                    if (!hasProp(defined, moduleName) && mod && !mod.inited && config.enforceDefine &&
+                        (!shExports || !getGlobal(shExports))
+                    ) {
                         if (hasPathFallback(moduleName)) {
                             return;
                         } else {
@@ -1605,10 +1607,10 @@ var requirejs, require, define;
                                              null,
                                              [moduleName]));
                         }
-                    } else {
+                    } else if (mod && !mod.inited) {
                         //A script that does not call define(), so just simulate
                         //the call for it.
-                        callGetModule([moduleName, (shim.deps || []), shim.exportsFn]);
+                        callGetModule([moduleName, (shim.deps || []), shim.exportsFn], true);
                     }
                 }
 


### PR DESCRIPTION
tmpl!foo/bar
xhtml!foo/bar

And both plugins uses method fromText() for evaluation. For example:
define('tmpl', ['text'], function(text) {
   return {
      load: function(name, require, load, conf) {
         try {
            var onLoad = function(data) {
               load.fromText(data);
            };
            onLoad.error = function(e) {
               load.error(e);
            };
            text.load(name + '.tmpl', require, onLoad, conf);
         } catch (e) {
            load.error(e);
         }
      }
   };
});

The module with plugin defined like this:
define('tmpl!foo/bar', function () {
   return function foo_bar_tmpl () {};
});

In that case async calls with various plugins works almost fine - evaluated code receives in callback successfully:
require(['tmpl!foo/bar'], function (bar) {
    console.log(bar)
});

setTimeout(function() {
    require(['xhtml!foo/bar'], function (bar) {
        console.log(bar)
    });
}, 1000);

But second call for 'xhtml!foo/bar' cause an unexpected GET request to foo/bar.js.

That's happened because module 'foo/bar' has in 'defined' since first call. But re-created not initialized in 'registry' in second call.