### PR TITLE
Added new configuration option "moduleExtension"

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -908,6 +908,11 @@ some modules to load asynchronously as part of a config block.</p>
 
 <p id="config-skipDataMain"><strong><a href="#config-skipDataMain">skipDataMain</a></strong>: Introduced in RequireJS 2.1.9: If set to <code>true</code>, skips the <a href="#data-main">data-main attribute scanning</a> done to start module loading. Useful if RequireJS is embedded in a utility library that may interact with other RequireJS library on the page, and the embedded version should not do data-main loading.</p>
 
+<p id="config-moduleExtension"><strong><a href="#config-moduleExtension">moduleExtension</a></strong>: Specify the module file extension with dot. Default is ".js". Useful when using gzip:</p>
+
+<pre><code>moduleExtension: ".jz.gz"
+</code></pre>
+
 </div>
 
 <div class="section">

--- a/require.js
+++ b/require.js
@@ -209,7 +209,8 @@ var requirejs, require, define;
                 bundles: {},
                 pkgs: {},
                 shim: {},
-                config: {}
+                config: {},
+                moduleExtension: '.js'
             },
             registry = {},
             //registry of just enabled modules, to speed
@@ -1671,7 +1672,7 @@ var requirejs, require, define;
 
                     //Join the path parts together, then figure out if baseUrl is needed.
                     url = syms.join('/');
-                    url += (ext || (/^data\:|^blob\:|\?/.test(url) || skipExt ? '' : '.js'));
+                    url += (ext || (/^data\:|^blob\:|\?/.test(url) || skipExt ? '' : config.moduleExtension));
                     url = (url.charAt(0) === '/' || url.match(/^[\w\+\.\-]+:/) ? '' : config.baseUrl) + url;
                 }
 


### PR DESCRIPTION
Hello.

One of our customers required us to gzip our modules. We would like to serve them with the .gz extension, but the current implementation does not allow to do this.

I added a new configuration option to allow that - moduleExtension. It is set to ".js" by default.

What do you think about it?