### PR TITLE
Do not defined script node type unless user is specified

### DIFF
--- a/require.js
+++ b/require.js
@@ -1876,7 +1876,9 @@ var requirejs, require, define;
         var node = config.xhtml ?
                 document.createElementNS('http://www.w3.org/1999/xhtml', 'html:script') :
                 document.createElement('script');
-        node.type = config.scriptType || 'text/javascript';
+        if (config.scriptType) {
+            node.type = config.scriptType;
+        }
         node.charset = 'utf-8';
         node.async = true;
         return node;


### PR DESCRIPTION
HTML5 specification urges authors to omit the attribute rather than provide a redundant MIME type.