### PR TITLE
Correct dead link to DOSKEY documentation.

### DIFF
--- a/docs/optimization.html
+++ b/docs/optimization.html
@@ -78,7 +78,7 @@ require(mods);</code></pre>
 </code></pre>
 
 <p>If on Windows, you may need to type <code>r.js.cmd</code> instead of <code>r.js</code>. Or, you can
-    use <a href="http://www.microsoft.com/resources/documentation/windows/xp/all/proddocs/en-us/doskey.mspx?mfr=true">DOSKEY</a>:</p>
+    use <a href="https://docs.microsoft.com/en-us/windows-server/administration/windows-commands/doskey">DOSKEY</a>:</p>
 
 <pre><code>DOSKEY r.js=r.js.cmd $*</code></pre>
 


### PR DESCRIPTION
The old link is now a 404.  This appears to be the new link.