### PR TITLE
fix missing version attribute in package json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "requirejs",
   "license": "MIT",
+  "version": "2.3.6",
   "volo": {
     "url": "https://raw.github.com/requirejs/requirejs/{version}/require.js"
   },


### PR DESCRIPTION
the missing version attribute will confuse yarn and other package manager if you try to prefix the modules for local usage. After adding the version attribute I was be able to also prefix requirejs to get my frontendjs and node_modules separated with yarn.

before:
$ yarn
yarn install v1.10.1
info No lockfile found.
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
error Can't add "@frontend_components/requirejs-toehrling": invalid package version undefined.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

after:
$ yarn
yarn install v1.10.1
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 📃  Building fresh packages...
success Saved lockfile.
✨  Done in 4.97s.
