### PR TITLE
Improve behavior of toUrl

### DIFF
--- a/require.js
+++ b/require.js
@@ -1485,20 +1485,20 @@ var requirejs, require, define;
                      * You may also use it to generate a URL that is relative to a module.
                      * To do so, ask for "require" as a dependency and then use require.toUrl() to generate the URL.
                      */
-                    toUrl: function (moduleNamePlusExt) {
+                    toUrl: function (path) {
                         var ext,
-                            index = findExtension(moduleNamePlusExt),
-                            segment = moduleNamePlusExt.split('/')[0],
+                            index = findExtension(path),
+                            segment = path.split('/')[0],
                             isRelative = segment === '.' || segment === '..';
 
                         //Have a file extension alias, and it is not the
                         //dots from a relative path.
                         if (index !== -1 && (!isRelative || index > 1)) {
-                            ext = moduleNamePlusExt.substring(index, moduleNamePlusExt.length);
-                            moduleNamePlusExt = moduleNamePlusExt.substring(0, index);
+                            ext = path.substring(index, path.length);
+                            path = path.substring(0, index);
                         }
 
-                        return context.nameToUrl(normalize(moduleNamePlusExt,
+                        return context.nameToUrl(normalize(path,
                                                 relMap && relMap.id, true), ext,  true);
                     },
 

--- a/require.js
+++ b/require.js
@@ -1467,17 +1467,27 @@ var requirejs, require, define;
                     return localRequire;
                 }
 
+
+                /**
+                 * This method finds the index of the '.' of a file extension un a valid url.
+                 * Regex is based on https://stackoverflow.com/questions/6997262/how-to-pull-url-file-extension-out-of-url-string-using-javascript
+                 */
+                function findExtension( url ) {
+                    var matchext = url.match(/\.([^\./\?\#]+)($|\?|\#)/);
+                    return matchext ? matchext.index : -1;
+                }
+		
                 mixin(localRequire, {
                     isBrowser: isBrowser,
 
                     /**
-                     * Converts a module name + .extension into an URL path.
-                     * *Requires* the use of a module name. It does not support using
-                     * plain URLs like nameToUrl.
+                     * This method converts a module name + .extension into an URL path.
+                     * You may also use it to generate a URL that is relative to a module.
+                     * To do so, ask for "require" as a dependency and then use require.toUrl() to generate the URL.
                      */
                     toUrl: function (moduleNamePlusExt) {
                         var ext,
-                            index = moduleNamePlusExt.lastIndexOf('.'),
+                            index = findExtension(moduleNamePlusExt),
                             segment = moduleNamePlusExt.split('/')[0],
                             isRelative = segment === '.' || segment === '..';
 


### PR DESCRIPTION
The current implementation seems to suggest `require.toUrl` should only be used to get the path of an AMD module, even though the documentation also mentions a different use :

````js
define(["require"], function(require) {
    var cssUrl = require.toUrl("./style.css");
});
````

Nevertheless, this method can't be used for all kinds of paths, like relative path that don't have an extension or paths that have components after the extension (which is not uncommon for a url).

This is because `require.toUrl` determines the position of the extension by taking the last dot of a path and considering everything starting from that dot as an extension.

This is very annoying, especially because this makes the behavior of `require.toUrl` different for RequireJS and the Dojo loader and results in invalid paths in RequireJS for even paths as simple and common as `../resources/`.

This could easily be fixed by determining the position of the extension with a regex, like this :  

````js
/**
 * This method finds the index of the '.' of a file extension un a valid url.
 * Regex is based on https://stackoverflow.com/questions/6997262/how-to-pull-url-file-extension-out-of-url-string-using-javascript
 */
function findExtension( url ) {
    var matchext = url.match(/\.([^\./\?\#]+)($|\?|\#)/);
    return matchext ? matchext.index : -1;
}
````

My pull requests contains three changes to the source code :

* I replaced `lastIndexOf` with this new `findExtension` function for determining the position of the extension
* I renamed the `moduleNamePlusExt` argument of `toUrl` to `path`, to reflect that can be used in different context
* I updated the comment to `toUrl`