### PR TITLE
Fix jQuery page footer

### DIFF
--- a/docs/jquery.html
+++ b/docs/jquery.html
@@ -33,6 +33,7 @@
 </h2>
 
 <p>While RequireJS loads jQuery just like any other dependency, jQuery's wide use and extensive plugin ecosystem mean you'll likely have other scripts in your project that also depend on jQuery. You might approach your jQuery RequireJS configuration differently depending on whether you are starting a new project or whether you are adapting existing code.</p>
+</div>
 
 <div class="section">
 <h2>


### PR DESCRIPTION
The jQuery page footer looks off. 

The doc pages are generated with `dist/pre.html` prepended, and `dist/post.html` appended. `pre.html` contains an open div tag for `<div class="content">` which is supposed to be closed in `post.html`. This relies on the page content having correct HTML tag matching, which unfortunately is off by one tag in this page.