### PR TITLE
Fix: Issue 1785 - IE11 - Requiring mixed content never resolves or errors

### DIFF
--- a/require.js
+++ b/require.js
@@ -1939,7 +1939,16 @@ var requirejs, require, define;
                 node.addEventListener('load', context.onScriptLoad, false);
                 node.addEventListener('error', context.onScriptError, false);
             }
-            node.src = url;
+            
+            try {
+                // Mixed Content
+                // Sane browsers do not reject mixed content until the node is appended to the DOM.
+                // However, IE throws earlier and prevents the node event listener to call our 'error' callback. 
+                // Result: The request is never sent and we get no notification on either 'load' or 'error' callbacks. 
+                node.src = url;
+            } catch (e) {
+                return context.onError(makeError('scripterror', 'Script error for: ' + moduleName + ' at ' + url, e, [moduleName]));
+            }
 
             //Calling onNodeCreated after all properties on the node have been
             //set, but before it is placed in the DOM.


### PR DESCRIPTION
https://github.com/requirejs/requirejs/issues/1785

Websites served over HTTPS will refuse to load HTTP urls by default.

While all browsers reject an attempt to require([ 'http://some/module' ]), the timing is different on IE.

IE throws an error when adding the node.src attribute
Other browsers error out when appending the node to the DOM.

In the Chrome/FF/Safari/etc... scenario, the error callback is triggered and the error is reported.
For IE, the script tags are never a part of the DOM and the callbacks for load or error are not invoked. The result is an unhandled exception coming from requirejs and the calling code is never notified of the failure.

### The Fix
Try/Catch around the action of adding the node.src, and notify the caller of the script error. 