### PR TITLE
Issues found by repeated loading/unloading with sometimes failures

### DIFF
--- a/require.js
+++ b/require.js
@@ -700,9 +700,9 @@ var requirejs, require, define;
                 err.contextName = context.contextName;
                 const ret = onError(err);
                 each(reqCalls, function (mod) {
-                  if (mod.map.id in enabledRegistry) {
-                      context.require.undef(mod.map.id);
-                  }
+                    if (mod.map.id in enabledRegistry) {
+                        context.require.undef(mod.map.id);
+                    }
                 });
                 return ret;
             }

--- a/require.js
+++ b/require.js
@@ -1467,6 +1467,7 @@ var requirejs, require, define;
                         requireMod.init(deps, callback, errback, {
                             enabled: true
                         });
+
                         checkLoaded();
                     });
 

--- a/require.js
+++ b/require.js
@@ -694,10 +694,17 @@ var requirejs, require, define;
             });
 
             if (expired && noLoads.length) {
+                inCheckLoaded = false;
                 //If wait time expired, throw error of unloaded modules.
                 err = makeError('timeout', 'Load timeout for modules: ' + noLoads, null, noLoads);
                 err.contextName = context.contextName;
-                return onError(err);
+                const ret = onError(err);
+                each(reqCalls, function (mod) {
+                  if (mod.map.id in enabledRegistry) {
+                      context.require.undef(mod.map.id);
+                  }
+                });
+                return ret;
             }
 
             //Not expired, check for a cycle.
@@ -1460,7 +1467,6 @@ var requirejs, require, define;
                         requireMod.init(deps, callback, errback, {
                             enabled: true
                         });
-
                         checkLoaded();
                     });
 


### PR DESCRIPTION
Hi,

I am using RequireJS in a project that requires repeatedly loading and unloading modules. I found 2 problems:

1.  Timeout cannot fire a second time.
2.  Some "anonymous" entries ("_@r??") were accumulated in the "registry" after failures.

I have tested using the given suite on up-to-date Edge, Chrome and Firefox.

Thanks!