### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tests/jquery/scripts/jquery-1.7.1.js
+++ b/tests/jquery/scripts/jquery-1.7.1.js
@@ -7470,7 +7470,7 @@ jQuery.extend({
 		// Apply prefilters
 		inspectPrefiltersOrTransports( prefilters, s, options, jqXHR );
 
-		// If request was aborted inside a prefiler, stop there
+		// If request was aborted inside a profiler, stop there
 		if ( state === 2 ) {
 			return false;
 		}

--- a/tests/secondLateConfigPlugin/app/lib_/amd/nonamd.js
+++ b/tests/secondLateConfigPlugin/app/lib_/amd/nonamd.js
@@ -133,7 +133,7 @@ define(["module", "text"], function(module, text) {
    *    When unspecified, the module value must instead be returned by the 
    *    code in the more general `postscript` option.
    * @param {Object.<string, string>} [moduleConfig.deps] A map of dependencies of the module, 
-   *    having as keys the module's define function argument names and as values the correposding module ids.
+   *    having as keys the module's define function argument names and as values the corresponding module ids.
    * @param {boolean} [isBuild=false] Whether running in build mode, under r.js.
    */
   function compileNonAmd(jsText, moduleConfig, isBuild) {


### PR DESCRIPTION
There are small typos in:
- tests/jquery/scripts/jquery-1.7.1.js
- tests/secondLateConfigPlugin/app/lib_/amd/nonamd.js

Fixes:
- Should read `profiler` rather than `prefiler`.
- Should read `corresponding` rather than `correposding`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md