### PR TITLE
Fixes #1864: proto/constructor check that works in ie6-8

### DIFF
--- a/require.js
+++ b/require.js
@@ -1,5 +1,5 @@
 /** vim: et:ts=4:sw=4:sts=4
- * @license RequireJS 2.3.7 Copyright jQuery Foundation and other contributors.
+ * @license RequireJS 2.3.7+ Copyright jQuery Foundation and other contributors.
  * Released under MIT license, https://github.com/requirejs/requirejs/blob/master/LICENSE
  */
 //Not using strict: uneven strict support in browsers, #392, and causes
@@ -11,7 +11,7 @@ var requirejs, require, define;
 (function (global, setTimeout) {
     var req, s, head, baseElement, dataMain, src,
         interactiveScript, currentlyAddingScript, mainScript, subPath,
-        version = '2.3.7',
+        version = '2.3.7+',
         commentRegExp = /\/\*[\s\S]*?\*\/|([^:"'=]|^)\/\/.*$/mg,
         cjsRequireRegExp = /[^.]\s*require\s*\(\s*["']([^'"\s]+)["']\s*\)/g,
         jsSuffixRegExp = /\.js$/,
@@ -33,8 +33,7 @@ var requirejs, require, define;
         contexts = {},
         cfg = {},
         globalDefQueue = [],
-        useInteractive = false,
-        disallowedProps = ['__proto__', 'constructor'];
+        useInteractive = false;
 
     //Could match something like ')//comment', do not lose the prefix to comment.
     function commentReplace(match, singlePrefix) {
@@ -95,7 +94,7 @@ var requirejs, require, define;
     function eachProp(obj, func) {
         var prop;
         for (prop in obj) {
-            if (hasProp(obj, prop) && disallowedProps.indexOf(prop) == -1) {
+            if (hasProp(obj, prop) && prop !== '__proto__' && prop !== 'constructor') {
                 if (func(obj[prop], prop)) {
                     break;
                 }


### PR DESCRIPTION
Same fix as #1856 but avoid using array indexOf for IE 6-8 which does not implement it.